### PR TITLE
Add bug report and feature request issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report a reproducible problem in FairShare
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+## Description
+A clear, concise description of what's wrong.
+
+## Steps to Reproduce
+1.
+2.
+3.
+
+## Actual Behaviour
+What actually happens (include error messages if any).
+
+## Expected Behaviour
+What should happen instead.
+
+## Environment
+- Branch/commit:
+- Browser/OS (if relevant):
+
+## Acceptance Criteria
+- [ ] **AC1 — Fix confirmed**
+  Given the reproduction steps above
+  When they are followed after the fix
+  Then the expected behaviour occurs instead of the bug
+
+## Additional Context
+Add more context if needed.
+
+<!-- If this depends on or blocks another issue, reference it inline, e.g. "Depends on #12" -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Propose a new feature or user story for FairShare
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+---
+
+## User Story
+As a [type of user],
+I want [goal],
+So that [benefit].
+
+## Acceptance Criteria
+- [ ] **AC1 — Title**
+  Given ...
+  When ...
+  Then ...
+
+<!-- If this depends on or blocks another issue, reference it inline, e.g. "Depends on #12" -->


### PR DESCRIPTION
Adds GitHub issue templates under `.github/ISSUE_TEMPLATE/` so all future issues follow a consistent structure.

**Bug report** — Description, Steps to Reproduce, Expected/Actual Behaviour, Environment, Acceptance Criteria, Additional Context.
**Feature request** — User Story, Acceptance Criteria in Given/When/Then format.

Both apply their default label (`bug` / `enhancement`) on creation. Fields GitHub handles natively (milestone, assignee, extra labels) are deliberately left out of the template bodies and set via the sidebar instead.

Note for reviewer: the template chooser only renders from the repository's default branch, so AC2 can't be verified until this is merged (I've verified this in my own fork). Everything else is checkable from the diff. Docs-only change, no tests apply.

Closes #18