### PR TITLE
Added MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-FairShare is licensed under the MIT license <https://mit-license.org/>
-
 The MIT License (MIT)
 Copyright © 2026 Aditeya Anand, Adrian Rohrbach, Jago Sutherland, Jason Huang, Johan Eger, Louis Cao, Suah Kim
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,10 @@
-TODO: Documentation team
+FairShare is licensed under the MIT license <https://mit-license.org/>
 
-Confirm the open-source licence with the full team and replace this entire file
-with the complete, unmodified licence text.
+The MIT License (MIT)
+Copyright © 2026 Aditeya Anand, Adrian Rohrbach, Jago Sutherland, Jason Huang, Johan Eger, Louis Cao, Suah Kim
 
-The generated template previously suggested the MIT Licence, but the team must
-make and record the final decision.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-This placeholder does not grant a software licence and must not remain in the
-final submission.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Updated LICENSE, providing a valid MIT license, resolves #26.
All members of SE310 Project Group 2 are listed as copyright holders, as the FairShare github organization is not a legal entity, and so cannot hold copyright.
Note that this license may need to be updated in the future if the project incorporates any tools or libraries that require a different license.