### PR TITLE
Configure MySQL persistence with Spring Data JPA

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -28,7 +28,31 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spring.application.name=FairShare
+# Supply SPRING_DATASOURCE_URL, SPRING_DATASOURCE_USERNAME, and
+# SPRING_DATASOURCE_PASSWORD through the runtime environment.
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.open-in-view=false

--- a/backend/src/test/java/nz/ac/auckland/se310/fairshare/FairShareApplicationTests.java
+++ b/backend/src/test/java/nz/ac/auckland/se310/fairshare/FairShareApplicationTests.java
@@ -3,7 +3,11 @@ package nz.ac.auckland.se310.fairshare;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        properties = "spring.autoconfigure.exclude="
+                + "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration,"
+                + "org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration")
 class FairShareApplicationTests {
 
     @Test

--- a/backend/src/test/java/nz/ac/auckland/se310/fairshare/MySqlPersistenceIntegrationTests.java
+++ b/backend/src/test/java/nz/ac/auckland/se310/fairshare/MySqlPersistenceIntegrationTests.java
@@ -1,0 +1,45 @@
+package nz.ac.auckland.se310.fairshare;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mysql.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers(disabledWithoutDocker = true)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class MySqlPersistenceIntegrationTests {
+
+    @Container
+    @ServiceConnection
+    static final MySQLContainer MYSQL = new MySQLContainer(
+            DockerImageName.parse("mysql:8.4"));
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void writesAndReadsDataFromMySql() {
+        jdbcTemplate.execute("""
+                CREATE TABLE persistence_probe (
+                    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                    message VARCHAR(255) NOT NULL
+                )
+                """);
+        jdbcTemplate.update(
+                "INSERT INTO persistence_probe (message) VALUES (?)",
+                "connected");
+
+        String storedMessage = jdbcTemplate.queryForObject(
+                "SELECT message FROM persistence_probe WHERE id = 1",
+                String.class);
+
+        assertThat(storedMessage).isEqualTo("connected");
+    }
+}

--- a/backend/src/test/java/nz/ac/auckland/se310/fairshare/MySqlPersistenceIntegrationTests.java
+++ b/backend/src/test/java/nz/ac/auckland/se310/fairshare/MySqlPersistenceIntegrationTests.java
@@ -12,7 +12,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.mysql.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
-@Testcontainers(disabledWithoutDocker = true)
+@Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 class MySqlPersistenceIntegrationTests {
 


### PR DESCRIPTION
## Summary

- add Spring Data JPA and the MySQL JDBC driver through Spring Boot dependency management
- configure Hibernate validation and environment-only datasource credentials
- add a Testcontainers MySQL integration test that creates a table, inserts a row, and reads it back
- require Docker-backed persistence verification to fail rather than silently skip when Docker is unavailable
- preserve the lightweight application-context test when no local database is configured
- document the complete local MySQL 8.4 database and user setup in the project Wiki

## Why

FairShare needs shared persistence infrastructure before feature-specific entities and repositories can be implemented.

Closes #22

## Validation

- `.\mvnw.cmd --batch-mode -Dtest=FairShareApplicationTests test` locally — 1 test, 0 failures, 0 errors, 0 skipped; build succeeded
- `.\mvnw.cmd --batch-mode clean verify` locally without Docker — failed with 2 tests, 1 error, 0 skipped and `Could not find a valid Docker environment`, confirming persistence verification no longer silently skips
- [GitHub Actions build](https://github.com/se310-fairshare/fairshare/actions/runs/31484302834) on Docker-enabled Ubuntu — `mysql:8.4` started, Hikari connected, 2 tests ran with 0 failures, 0 errors, 0 skipped; build succeeded
- SonarCloud and Snyk checks passed
- `git diff --check` passed for the repository and Wiki changes
- [MySQL persistence setup](https://github.com/se310-fairshare/fairshare/wiki/MySQL-Persistence-Setup) now includes MySQL 8.4, database/user creation SQL, environment variables, and Docker requirements
- confirmed no database credentials are committed
- confirmed the branch remains based on the current `upstream/main`

## Review notes

Johan's review feedback has been addressed in commit `9ce0fb9` and Wiki commit `e64805f`. The schema-migration follow-up is tracked separately in #37 and remains unassigned pending team approval.

Please verify the latest commit and provide a formal GitHub approval. This PR should remain unmerged until both assigned reviewers approve it.

## Generative AI acknowledgement

Generative AI assisted with implementation planning, test scaffolding, review-feedback handling, and auditing. The dependency configuration, code, documentation, issue scope, and verification results were manually reviewed.
