### PR TITLE
Add version-controlled database schema migrations

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -37,6 +37,14 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-flyway</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
@@ -55,21 +63,12 @@
             <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-            <dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-mysql</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-flyway</artifactId>
-        </dependency>
-        
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,13 +1,10 @@
 spring.application.name=FairShare
-spring.datasource.url=jdbc:mysql://localhost:3306/fairshare
-
-#INSERT YOUR USERNAME eg. spring.datasource.username=my_username
-spring.datasource.username={INSERT_USERNAME}
-#INSERT YOUR PASSWORD eg. spring.datasource.username=my_password
-spring.datasource.password={INSERT_PASSWORD}
+# Supply SPRING_DATASOURCE_URL, SPRING_DATASOURCE_USERNAME, and
+# SPRING_DATASOURCE_PASSWORD through the runtime environment.
 
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
+spring.flyway.validate-migration-naming=true
 
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.open-in-view=false

--- a/backend/src/main/resources/db/migration/V1__create_users_table.sql
+++ b/backend/src/main/resources/db/migration/V1__create_users_table.sql
@@ -1,8 +1,8 @@
 CREATE TABLE users (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    username VARCHAR(255),
-    password VARCHAR(255),
-    email VARCHAR(255),
+    username VARCHAR(255) NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
     country VARCHAR(255),
     currency VARCHAR(255)
 );

--- a/backend/src/test/java/nz/ac/auckland/se310/fairshare/MySqlPersistenceIntegrationTests.java
+++ b/backend/src/test/java/nz/ac/auckland/se310/fairshare/MySqlPersistenceIntegrationTests.java
@@ -25,13 +25,7 @@ class MySqlPersistenceIntegrationTests {
     private JdbcTemplate jdbcTemplate;
 
     @Test
-    void writesAndReadsDataFromMySql() {
-        jdbcTemplate.execute("""
-                CREATE TABLE persistence_probe (
-                    id BIGINT PRIMARY KEY AUTO_INCREMENT,
-                    message VARCHAR(255) NOT NULL
-                )
-                """);
+    void appliesMigrationsAndPersistsData() {
         jdbcTemplate.update(
                 "INSERT INTO persistence_probe (message) VALUES (?)",
                 "connected");
@@ -41,5 +35,16 @@ class MySqlPersistenceIntegrationTests {
                 String.class);
 
         assertThat(storedMessage).isEqualTo("connected");
+
+        var appliedVersions = jdbcTemplate.queryForList(
+                """
+                SELECT version
+                FROM flyway_schema_history
+                WHERE success = TRUE
+                ORDER BY installed_rank
+                """,
+                String.class);
+
+        assertThat(appliedVersions).contains("1", "9999");
     }
 }

--- a/backend/src/test/resources/db/migration/V9999__create_persistence_probe.sql
+++ b/backend/src/test/resources/db/migration/V9999__create_persistence_probe.sql
@@ -1,0 +1,4 @@
+CREATE TABLE persistence_probe (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    message VARCHAR(255) NOT NULL
+);


### PR DESCRIPTION
## Summary

- configure Flyway for the Maven backend and MySQL
- use `V1__create_users_table.sql` as the production migration and align it with the `User` mapping
- keep datasource credentials supplied through runtime environment variables
- move the persistence probe table into a test-only migration
- verify applied Flyway migrations in the MySQL Testcontainers test
- document the migration workflow in the existing MySQL persistence Wiki page

Closes #37.

## Testing

- `.\mvnw.cmd --batch-mode clean verify` - passed locally with Docker
- `npm run build` - passed
- GitHub Actions CI - passed
- SonarCloud Code Analysis - passed
- Snyk PR check - passed

## Documentation

- [MySQL Persistence Setup](https://github.com/se310-fairshare/fairshare/wiki/MySQL-Persistence-Setup)