### PR TITLE
feat: add backend support for creating expense groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
         working-directory: frontend
         run: npm ci
 
+      - name: Test frontend
+        working-directory: frontend
+        run: npm test
+
       - name: Build frontend
         working-directory: frontend
         run: npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Persistence uses MySQL through Spring Data JPA and Hibernate, tracked under issu
 Datasource credentials are supplied only through environment variables and are never committed.
 Hibernate runs with `ddl-auto=validate`, so it checks entity mappings against the existing schema and never creates or alters tables; schema changes come from version-controlled migrations, tracked under issue [#37](https://github.com/se310-fairshare/fairshare/issues/37).
 Backend testing uses JUnit and Mockito, with Testcontainers for database integration tests.
-Frontend testing with Vitest is tracked separately.
+Frontend testing uses Vitest with React Testing Library, with test files under `frontend/test/`.
 
 ## First contributions
 
@@ -132,15 +132,18 @@ cd backend
 ./mvnw --batch-mode clean verify
 ```
 
-The frontend has no test harness yet, so verification is limited to a production build:
+The frontend test suite runs through npm and needs no additional services. Tests use Vitest with React Testing Library and jsdom.
 
-```bash
-cd frontend
-npm ci
-npm run build
-```
+    cd frontend
+    npm ci
+    npm test
 
-Both commands are run by the CI workflow on every push to `main` and on every pull request targeting `main`.
+A production build is verified separately:
+
+    cd frontend
+    npm run build
+
+Both commands are run by the CI workflow on every push to main and on every pull request targeting main.
 
 ## The contribution workflow
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -67,6 +67,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/AppConfig.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/AppConfig.java
@@ -3,11 +3,9 @@ package nz.ac.auckland.se310.fairshare;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -38,25 +36,5 @@ public class AppConfig {
     source.registerCorsConfiguration("/**", configuration);
 
     return source;
-  }
-
-  @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    // this exists because login system is currently not set up
-    http.cors(
-            cors -> {}) // enables spring security cross origins resource sharing (CORS) so that the
-        // backend can handle requests coming from frontend
-        .csrf(
-            csrf ->
-                csrf.disable()) // disables csrf protection so spring security won't require CSRF
-        // tokens(some requests may be denied if it is not disabled)
-        .authorizeHttpRequests(
-            auth ->
-                auth.requestMatchers("/users/register")
-                    .permitAll()
-                    .anyRequest()
-                    .authenticated()); // allows everyone to access endpoints (no authentication
-    // needed)
-    return http.build();
   }
 }

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/controller/ExpenseGroupController.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/controller/ExpenseGroupController.java
@@ -1,0 +1,43 @@
+package nz.ac.auckland.se310.fairshare.controller;
+
+import jakarta.validation.Valid;
+import nz.ac.auckland.se310.fairshare.dto.CreateGroupRequest;
+import nz.ac.auckland.se310.fairshare.dto.GroupResponse;
+import nz.ac.auckland.se310.fairshare.security.CurrentUserProvider;
+import nz.ac.auckland.se310.fairshare.service.ExpenseGroupService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/groups")
+public class ExpenseGroupController {
+
+    private final ExpenseGroupService groupService;
+    private final CurrentUserProvider currentUser;
+
+    public ExpenseGroupController(ExpenseGroupService groupService, CurrentUserProvider currentUser) {
+        this.groupService = groupService;
+        this.currentUser = currentUser;
+    }
+
+    @PostMapping
+    public ResponseEntity<GroupResponse> create(@Valid @RequestBody CreateGroupRequest request) {
+        GroupResponse created = groupService.createGroup(request, currentUser.currentUserId());
+        return ResponseEntity
+                .created(URI.create("/groups/" + created.id()))
+                .body(created);
+    }
+
+    @GetMapping
+    public List<GroupResponse> list() {
+        return groupService.getGroupsForUser(currentUser.currentUserId());
+    }
+
+    @GetMapping("/{id}")
+    public GroupResponse get(@PathVariable Long id) {
+        return groupService.getGroup(id, currentUser.currentUserId());
+    }
+}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/dto/CreateGroupRequest.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/dto/CreateGroupRequest.java
@@ -1,0 +1,10 @@
+package nz.ac.auckland.se310.fairshare.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateGroupRequest(
+        @NotBlank(message = "Group name is required")
+        @Size(max = 50, message = "Group name must be at most 50 characters")
+        String name,
+        String description) {}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/dto/CreateGroupRequest.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/dto/CreateGroupRequest.java
@@ -7,4 +7,6 @@ public record CreateGroupRequest(
         @NotBlank(message = "Group name is required")
         @Size(max = 50, message = "Group name must be at most 50 characters")
         String name,
+
+        @Size(max = 255, message = "Description must be at most 255 characters")
         String description) {}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/dto/GroupResponse.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/dto/GroupResponse.java
@@ -1,0 +1,7 @@
+package nz.ac.auckland.se310.fairshare.dto;
+
+import java.time.Instant;
+
+public record GroupResponse(
+        Long id, String name, String description,
+        String baseCurrency, Instant createdAt, int memberCount) {}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/exception/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package nz.ac.auckland.se310.fairshare.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidation(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors()
+                .forEach(error -> errors.put(error.getField(), error.getDefaultMessage()));
+        return ResponseEntity.badRequest().body(errors);
+    }
+
+    @ExceptionHandler(GroupNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleGroupNotFound(GroupNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Map.of("error", "Group not found"));
+    }
+}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/exception/GroupNotFoundException.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/exception/GroupNotFoundException.java
@@ -1,0 +1,8 @@
+package nz.ac.auckland.se310.fairshare.exception;
+
+public class GroupNotFoundException extends RuntimeException {
+
+    public GroupNotFoundException(Long groupId) {
+        super("Group not found: " + groupId);
+    }
+}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/model/ExpenseGroup.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/model/ExpenseGroup.java
@@ -1,0 +1,84 @@
+package nz.ac.auckland.se310.fairshare.model;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Instant;
+import java.util.*;
+
+@Entity
+@Table(name="expense_group")
+public class ExpenseGroup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "group_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "created_by", nullable = false, updatable = false)
+    private User createdBy;
+
+    @Column(name = "group_name", nullable = false, length = 50)
+    private String groupName;
+
+    @Column(length = 255)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.CHAR)
+    @Column(name = "base_currency", nullable = false, length = 3)
+    private User.Currency baseCurrency;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<UserInGroup> members = new HashSet<>();
+
+    protected ExpenseGroup() {} // JPA
+
+    public ExpenseGroup(String groupName, String description, User.Currency baseCurrency, User createdBy) {
+        this.groupName = groupName;
+        this.description = description;
+        this.baseCurrency = baseCurrency;
+        this.createdBy = createdBy;
+        this.createdAt = Instant.now();
+        addMember(createdBy); // AC1: the creator is always a member
+    }
+
+    public void addMember(User user) {
+        members.add(new UserInGroup(this, user));
+    }
+
+    public void removeMember(User user) {
+        if (user.getId().equals(createdBy.getId())) {
+            throw new IllegalStateException("The group creator cannot leave the group");
+        }
+        members.removeIf(m -> m.getUser().getId().equals(user.getId()));
+    }
+
+    public Long getId() { return id; }
+    public String getGroupName() { return groupName; }
+    public String getDescription() { return description; }
+    public User.Currency getBaseCurrency() { return baseCurrency; }
+    public Instant getCreatedAt() { return createdAt; }
+    public User getCreatedBy() { return createdBy; }
+
+    public Set<UserInGroup> getMembers() {
+        return Collections.unmodifiableSet(members);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ExpenseGroup other)) return false;
+        return id != null && id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/model/User.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/model/User.java
@@ -86,4 +86,6 @@ public class User {
   public void setCurrency(Currency currency) {
     this.currency = currency;
   }
+
+  public Long getId() {return id; }
 }

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/model/UserInGroup.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/model/UserInGroup.java
@@ -1,0 +1,47 @@
+package nz.ac.auckland.se310.fairshare.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(
+        name = "user_in_group",
+        uniqueConstraints =
+        @UniqueConstraint(name = "uq_uig_user_group", columnNames = {"user_id", "group_id"}))
+public class UserInGroup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_in_group_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "group_id", nullable = false)
+    private ExpenseGroup group;
+
+    protected UserInGroup() {} // JPA
+
+    UserInGroup(ExpenseGroup group, User user) {
+        this.group = group;
+        this.user = user;
+    }
+
+    public Long getId() { return id; }
+    public User getUser() { return user; }
+    public ExpenseGroup getGroup() { return group; }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof UserInGroup other)) return false;
+        return id != null && id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/repository/ExpenseGroupRepository.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/repository/ExpenseGroupRepository.java
@@ -1,0 +1,16 @@
+package nz.ac.auckland.se310.fairshare.repository;
+
+import nz.ac.auckland.se310.fairshare.model.ExpenseGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ExpenseGroupRepository extends JpaRepository<ExpenseGroup, Long> {
+
+    // AC8: only returns the group if the requesting user is a member
+    Optional<ExpenseGroup> findByIdAndMembersUserId(Long groupId, Long userId);
+
+    // AC5: the user's groups overview, newest first
+    List<ExpenseGroup> findByMembersUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/security/CurrentUserProvider.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/security/CurrentUserProvider.java
@@ -1,0 +1,5 @@
+package nz.ac.auckland.se310.fairshare.security;
+
+public interface CurrentUserProvider {
+    Long currentUserId();
+}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/security/DevSecurityConfig.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/security/DevSecurityConfig.java
@@ -1,0 +1,28 @@
+package nz.ac.auckland.se310.fairshare.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Development-only security configuration.
+ *
+ * <p>Permits all requests so features can be built before authentication exists.
+ * Replaced by the real chain in issue #NN. Only active under the "dev" profile.
+ */
+@Configuration
+@Profile("dev")
+public class DevSecurityConfig {
+
+    @Bean
+    @Order(1)
+    public SecurityFilterChain devFilterChain(HttpSecurity http) {
+        http.cors(cors -> {})
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/security/SecurityConfig.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/security/SecurityConfig.java
@@ -1,0 +1,29 @@
+package nz.ac.auckland.se310.fairshare.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Default security chain. Superseded by {@link DevSecurityConfig} under the "dev"
+ * profile, because Spring Security rejects two chains that both match any request.
+ *
+ * <p>TODO(#NN): no authentication mechanism is configured yet, so every endpoint
+ * except /users/register is currently unreachable.
+ */
+@Configuration
+@Profile("!dev")
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) {
+        http.cors(cors -> {})
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth ->
+                        auth.requestMatchers("/users/register").permitAll()
+                                .anyRequest().authenticated());
+        return http.build();
+    }
+}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/security/StubCurrentUserProvider.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/security/StubCurrentUserProvider.java
@@ -1,0 +1,25 @@
+package nz.ac.auckland.se310.fairshare.security;
+
+import nz.ac.auckland.se310.fairshare.UserRepository;
+import nz.ac.auckland.se310.fairshare.model.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StubCurrentUserProvider implements CurrentUserProvider {
+
+    private final UserRepository userRepository;
+
+    public StubCurrentUserProvider(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    // TODO: replaced by a SecurityContext-backed implementation in issue #NN
+    @Override
+    public Long currentUserId() {
+        return userRepository.findAll().stream()
+                .findFirst()
+                .map(User::getId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "No users in the database. Register one before using the dev profile."));
+    }
+}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/service/ExpenseGroupService.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/service/ExpenseGroupService.java
@@ -1,0 +1,65 @@
+package nz.ac.auckland.se310.fairshare.service;
+
+
+import nz.ac.auckland.se310.fairshare.UserRepository;
+import nz.ac.auckland.se310.fairshare.dto.CreateGroupRequest;
+import nz.ac.auckland.se310.fairshare.dto.GroupResponse;
+import nz.ac.auckland.se310.fairshare.exception.GroupNotFoundException;
+import nz.ac.auckland.se310.fairshare.model.ExpenseGroup;
+import nz.ac.auckland.se310.fairshare.model.User;
+import nz.ac.auckland.se310.fairshare.repository.ExpenseGroupRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class ExpenseGroupService {
+
+    private final ExpenseGroupRepository groupRepository;
+    private final UserRepository userRepository;
+
+    public ExpenseGroupService(ExpenseGroupRepository groupRepository, UserRepository userRepository) {
+        this.groupRepository = groupRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public GroupResponse createGroup(CreateGroupRequest request, Long creatorId) {
+        User creator = userRepository.findById(creatorId)
+                .orElseThrow(() -> new IllegalStateException("Authenticated user not found: " + creatorId));
+
+        ExpenseGroup group = new ExpenseGroup(
+                request.name().trim(),
+                request.description(),
+                creator.getCurrency(),   // AC: base currency defaults from the creator
+                creator);
+
+        return toResponse(groupRepository.save(group));
+    }
+
+    @Transactional(readOnly = true)
+    public List<GroupResponse> getGroupsForUser(Long userId) {
+        return groupRepository.findByMembersUserIdOrderByCreatedAtDesc(userId)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public GroupResponse getGroup(Long groupId, Long userId) {
+        return groupRepository.findByIdAndMembersUserId(groupId, userId)
+                .map(this::toResponse)
+                .orElseThrow(() -> new GroupNotFoundException(groupId));  // AC8
+    }
+
+    private GroupResponse toResponse(ExpenseGroup group) {
+        return new GroupResponse(
+                group.getId(),
+                group.getGroupName(),
+                group.getDescription(),
+                group.getBaseCurrency().name(),
+                group.getCreatedAt(),
+                group.getMembers().size());
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -9,3 +9,4 @@ spring.flyway.validate-migration-naming=true
 
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.open-in-view=false
+spring.profiles.active=dev

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 spring.application.name=FairShare
 # Supply SPRING_DATASOURCE_URL, SPRING_DATASOURCE_USERNAME, and
 # SPRING_DATASOURCE_PASSWORD through the runtime environment.
+spring.config.import=optional:file:.env[.properties]
 
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration

--- a/backend/src/main/resources/db/migration/V2__create_groups_table.sql
+++ b/backend/src/main/resources/db/migration/V2__create_groups_table.sql
@@ -1,0 +1,25 @@
+CREATE TABLE expense_group (
+                               group_id      BIGINT AUTO_INCREMENT PRIMARY KEY,
+                               created_by    BIGINT       NOT NULL,
+                               group_name    VARCHAR(50)  NOT NULL,
+                               description   VARCHAR(255) NULL,
+                               base_currency CHAR(3)      NOT NULL,
+                               created_at    TIMESTAMP    NOT NULL,
+                               CONSTRAINT fk_group_created_by
+                                   FOREIGN KEY (created_by) REFERENCES users (id)
+);
+
+-- group_name is intentionally not unique: a user may belong to
+-- multiple groups with the same name They are distinguished by
+-- group_id, created_at and membership.
+
+CREATE TABLE user_in_group (
+                            user_in_group_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                            user_id  BIGINT NOT NULL,
+                            group_id BIGINT NOT NULL,
+                            CONSTRAINT uq_uig_user_group UNIQUE (user_id, group_id),
+                            CONSTRAINT fk_uig_user
+                               FOREIGN KEY (user_id) REFERENCES users (id),
+                            CONSTRAINT fk_uig_group
+                               FOREIGN KEY (group_id) REFERENCES expense_group (group_id)
+);

--- a/backend/src/test/java/nz/ac/auckland/se310/fairshare/ExpenseGroupIntegrationTest.java
+++ b/backend/src/test/java/nz/ac/auckland/se310/fairshare/ExpenseGroupIntegrationTest.java
@@ -1,0 +1,87 @@
+package nz.ac.auckland.se310.fairshare;
+
+import nz.ac.auckland.se310.fairshare.dto.CreateGroupRequest;
+import nz.ac.auckland.se310.fairshare.dto.GroupResponse;
+import nz.ac.auckland.se310.fairshare.exception.GroupNotFoundException;
+import nz.ac.auckland.se310.fairshare.repository.ExpenseGroupRepository;
+import nz.ac.auckland.se310.fairshare.service.ExpenseGroupService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mysql.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Import(TestCurrentUserConfig.class)
+class ExpenseGroupIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static final MySQLContainer MYSQL = new MySQLContainer(DockerImageName.parse("mysql:8.4"));
+
+    @Autowired ExpenseGroupService groupService;
+    @Autowired ExpenseGroupRepository groupRepository;
+    @Autowired UserRepository userRepository;
+
+    private Long aliceId;
+    private Long bobId;
+
+    @BeforeEach
+    void setUp() {
+        groupRepository.deleteAll();
+        var users = userRepository.findAll();
+        aliceId = users.get(0).getId();
+        bobId = users.get(1).getId();
+    }
+
+    @Test
+    void ac1_createsGroupWithCreatorAsMember() {
+        GroupResponse created = groupService.createGroup(new CreateGroupRequest("Flat 3", null), aliceId);
+
+        assertThat(created.id()).isNotNull();
+        assertThat(created.memberCount()).isEqualTo(1);
+        assertThat(groupRepository.findByIdAndMembersUserId(created.id(), aliceId)).isPresent();
+    }
+
+    @Test
+    void ac5_overviewListsOnlyGroupsTheUserBelongsTo() {
+        groupService.createGroup(new CreateGroupRequest("Alice one", null), aliceId);
+        groupService.createGroup(new CreateGroupRequest("Alice two", null), aliceId);
+        groupService.createGroup(new CreateGroupRequest("Bob one", null), bobId);
+
+        assertThat(groupService.getGroupsForUser(aliceId))
+                .hasSize(2)
+                .extracting(GroupResponse::name)
+                .containsExactlyInAnyOrder("Alice one", "Alice two");
+
+        assertThat(groupService.getGroupsForUser(bobId)).hasSize(1);
+    }
+
+    @Test
+    void ac6_duplicateNamesGetDistinctIdentifiers() {
+        GroupResponse first = groupService.createGroup(new CreateGroupRequest("Trip", null), aliceId);
+        GroupResponse second = groupService.createGroup(new CreateGroupRequest("Trip", null), aliceId);
+
+        assertThat(first.id()).isNotEqualTo(second.id());
+        assertThat(groupService.getGroupsForUser(aliceId)).hasSize(2);
+    }
+
+    @Test
+    void ac8_nonMemberCannotReadGroup() {
+        GroupResponse created = groupService.createGroup(new CreateGroupRequest("Alice's flat", null), aliceId);
+
+        Long groupId = created.id();
+
+        assertThatThrownBy(() -> groupService.getGroup(groupId, bobId))
+                .isInstanceOf(GroupNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/nz/ac/auckland/se310/fairshare/TestCurrentUserConfig.java
+++ b/backend/src/test/java/nz/ac/auckland/se310/fairshare/TestCurrentUserConfig.java
@@ -1,0 +1,22 @@
+package nz.ac.auckland.se310.fairshare;
+
+import nz.ac.auckland.se310.fairshare.security.CurrentUserProvider;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+@TestConfiguration
+public class TestCurrentUserConfig {
+
+    public static class SwitchableCurrentUserProvider implements CurrentUserProvider {
+        private Long userId;
+        public void setUserId(Long userId) { this.userId = userId; }
+        @Override public Long currentUserId() { return userId; }
+    }
+
+    @Bean
+    @Primary
+    public SwitchableCurrentUserProvider currentUserProvider() {
+        return new SwitchableCurrentUserProvider();
+    }
+}

--- a/backend/src/test/resources/db/migration/V9998__seed_test_users.sql
+++ b/backend/src/test/resources/db/migration/V9998__seed_test_users.sql
@@ -1,0 +1,3 @@
+INSERT INTO users (username, password, email, country, currency)
+VALUES ('alice', 'x', 'alice@test.com', 'NEW_ZEALAND', 'NZD'),
+       ('bob',   'x', 'bob@test.com',   'NEW_ZEALAND', 'NZD');

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.0.1",
       "dependencies": {
         "react": "^19.2.8",
-        "react-dom": "^19.2.8"
+        "react-dom": "^19.2.8",
+        "react-router-dom": "^7.18.2"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.4",
         "@vitejs/plugin-react": "^6.0.5",
         "jsdom": "^30.0.1",
         "vite": "^8.2.0",
@@ -66,7 +68,6 @@
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
@@ -82,7 +83,6 @@
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -198,6 +198,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -246,6 +247,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -616,13 +618,26 @@
         }
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.4.tgz",
+      "integrity": "sha512-QCGwP6QrjypBLwyj5cuyfVamkaIEy/XGY+1VDehbtbQqOggYmTFpFOdWR5mPz14vX8vXLMVjDHlRNBcClyO9ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -794,7 +809,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -805,7 +819,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -859,6 +872,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
@@ -942,8 +968,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "8.0.0",
@@ -1053,8 +1078,7 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "30.0.1",
@@ -1062,6 +1086,7 @@
       "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^6.0.5",
         "@asamuzakjp/dom-selector": "^8.3.0",
@@ -1374,7 +1399,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -1472,6 +1496,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1514,7 +1539,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -1539,6 +1563,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1548,6 +1573,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -1560,8 +1586,45 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-router": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -1637,6 +1700,12 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/siginfo": {
@@ -1796,6 +1865,7 @@
       "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,15 +5,18 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^19.2.8",
-    "react-dom": "^19.2.8"
+    "react-dom": "^19.2.8",
+    "react-router-dom": "^7.18.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.4",
     "@vitejs/plugin-react": "^6.0.5",
     "jsdom": "^30.0.1",
     "vite": "^8.2.0",

--- a/frontend/src/UserProfile.jsx
+++ b/frontend/src/UserProfile.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import './UserProfile.css';
 
 const countries = [
   { name: 'New Zealand', value: 'NEW_ZEALAND', currency: 'NZD' },
@@ -103,7 +102,7 @@ function UserProfile() {
 
   return (
     <div className="page">
-      <div className="profile-card">
+      <div className="card">
         <h1>Create Your Profile</h1>
         <p className="subtitle">Enter your information below</p>
 

--- a/frontend/src/api/config.js
+++ b/frontend/src/api/config.js
@@ -1,0 +1,1 @@
+export const API_BASE = 'http://localhost:8080';

--- a/frontend/src/api/groups.js
+++ b/frontend/src/api/groups.js
@@ -1,0 +1,33 @@
+import {API_BASE} from "./config.js";
+
+import(API_BASE)
+
+export async function createGroup(name, description) {
+    const response = await fetch(`${API_BASE}/groups`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ name, description })
+    });
+
+    if (response.status === 400) {
+        return { errors: await response.json() };
+    }
+    if (!response.ok) {
+        throw new Error(`Failed to create group: ${response.status}`);
+    }
+    return { group: await response.json() };
+}
+
+export async function getGroups() {
+    const response = await fetch(`${API_BASE}/groups`, { credentials: 'include' });
+    if (!response.ok) throw new Error(`Failed to load groups: ${response.status}`);
+    return response.json();
+}
+
+export async function getGroup(id) {
+    const response = await fetch(`${API_BASE}/groups/${id}`, { credentials: 'include' });
+    if (response.status === 404) return null;
+    if (!response.ok) throw new Error(`Failed to load group: ${response.status}`);
+    return response.json();
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15,7 +15,7 @@ body {
     align-items: center;
 }
 
-.profile-card {
+.card {
     width: 400px;
     padding: 40px;
     background-color: white;
@@ -23,7 +23,7 @@ body {
     box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
 }
 
-.profile-card h1 {
+.card h1 {
     margin: 0;
     text-align: center;
 }
@@ -45,14 +45,17 @@ body {
     font-weight: bold;
 }
 
-.form-group input {
+.form-group input,
+.form-group select {
     padding: 10px;
     font-size: 16px;
     border: 1px solid #ccc;
     border-radius: 5px;
+    background-color: white;
 }
 
-.form-group input:focus {
+.form-group input:focus,
+.form-group select:focus {
     outline: none;
     border-color: #555;
 }
@@ -63,6 +66,12 @@ body {
     color: #d32f2f;
 }
 
+.empty {
+    color: #666;
+    text-align: center;
+    margin: 20px 0;
+}
+
 button {
     width: 100%;
     padding: 12px;
@@ -71,17 +80,4 @@ button {
     border: none;
     border-radius: 5px;
     cursor: pointer;
-}
-
-.form-group select {
-    padding: 10px;
-    font-size: 16px;
-    border: 1px solid #ccc;
-    border-radius: 5px;
-    background-color: white;
-}
-
-.form-group select:focus {
-    outline: none;
-    border-color: #555;
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,9 +1,22 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import UserProfile from './UserProfile.jsx';
+import GroupsOverview from './pages/GroupsOverview.jsx';
+import CreateGroup from './pages/CreateGroup.jsx';
+import GroupPage from './pages/GroupPage.jsx';
+import './index.css';
 
 createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <UserProfile />
-  </StrictMode>,
+    <StrictMode>
+        <BrowserRouter>
+            <Routes>
+                <Route path="/" element={<Navigate to="/groups" replace />} />
+                <Route path="/register" element={<UserProfile />} />
+                <Route path="/groups" element={<GroupsOverview />} />
+                <Route path="/groups/new" element={<CreateGroup />} />
+                <Route path="/groups/:id" element={<GroupPage />} />
+            </Routes>
+        </BrowserRouter>
+    </StrictMode>,
 );

--- a/frontend/src/pages/CreateGroup.jsx
+++ b/frontend/src/pages/CreateGroup.jsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { createGroup } from '../api/groups';
+
+function CreateGroup() {
+    const [name, setName] = useState('');
+    const [description, setDescription] = useState('');
+    const [errors, setErrors] = useState({});
+    const [submitting, setSubmitting] = useState(false);
+    const navigate = useNavigate();
+
+    async function handleSubmit(event) {
+        event.preventDefault();
+        setSubmitting(true);
+        setErrors({});
+
+        try {
+            const result = await createGroup(name, description || null);
+
+            if (result.errors) {
+                setErrors(result.errors);        // AC3, AC4: inline field errors
+                return;
+            }
+
+            navigate(`/groups/${result.group.id}`);   // AC1: taken to the new group's page
+        } catch (error) {
+            console.error('Failed to create group', error)
+            setErrors({ form: 'Could not create the group. Please try again.' });
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <div className="page">
+            <div className="profile-card">
+                <h1>Create a Group</h1>
+                <p className="subtitle">Name your flat, trip or event</p>
+
+                <form onSubmit={handleSubmit}>
+                    <div className="form-group">
+                        <label htmlFor="name">Group name</label>
+                        <input
+                            id="name"
+                            type="text"
+                            value={name}
+                            placeholder="Enter a group name"
+                            onChange={(event) => setName(event.target.value)}
+                        />
+                        {errors.name && <span className="error">{errors.name}</span>}
+                    </div>
+
+                    <div className="form-group">
+                        <label htmlFor="description">Description (optional)</label>
+                        <input
+                            id="description"
+                            type="text"
+                            value={description}
+                            placeholder="What is this group for?"
+                            onChange={(event) => setDescription(event.target.value)}
+                        />
+                    </div>
+
+                    {errors.form && <span className="error">{errors.form}</span>}
+
+                    <button type="submit" disabled={submitting}>
+                        {submitting ? 'Creating…' : 'Create Group'}
+                    </button>
+                </form>
+            </div>
+        </div>
+    );
+}
+
+export default CreateGroup;

--- a/frontend/src/pages/CreateGroup.jsx
+++ b/frontend/src/pages/CreateGroup.jsx
@@ -33,7 +33,7 @@ function CreateGroup() {
 
     return (
         <div className="page">
-            <div className="profile-card">
+            <div className="card">
                 <h1>Create a Group</h1>
                 <p className="subtitle">Name your flat, trip or event</p>
 
@@ -59,6 +59,7 @@ function CreateGroup() {
                             placeholder="What is this group for?"
                             onChange={(event) => setDescription(event.target.value)}
                         />
+                        {errors.description && <span className="error">{errors.description}</span>}
                     </div>
 
                     {errors.form && <span className="error">{errors.form}</span>}

--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -1,0 +1,10 @@
+.group-card h2 {
+    margin: 30px 0 10px;
+    font-size: 18px;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 6px;
+}
+
+.balance {
+    color: #333;
+}

--- a/frontend/src/pages/GroupPage.jsx
+++ b/frontend/src/pages/GroupPage.jsx
@@ -36,7 +36,7 @@ function GroupPage() {
     if (notFound) {
         return (
             <div className="page">
-                <div className="group-card">
+                <div className="card">
                     <h1>Group not found</h1>
                     <p className="empty">This group does not exist, or you are not a member of it.</p>
                     <Link to="/groups">Back to your groups</Link>
@@ -48,7 +48,7 @@ function GroupPage() {
     if (error) {
         return (
             <div className="page">
-                <div className="group-card">
+                <div className="card">
                     <span className="error">{error}</span>
                     <Link to="/groups">Back to your groups</Link>
                 </div>
@@ -58,7 +58,7 @@ function GroupPage() {
 
     return (
         <div className="page">
-            <div className="group-card">
+            <div className="card">
                 <h1>{group.name}</h1>
                 {group.description && <p className="subtitle">{group.description}</p>}
 

--- a/frontend/src/pages/GroupPage.jsx
+++ b/frontend/src/pages/GroupPage.jsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { getGroup } from '../api/groups';
+import './GroupPage.css';
+
+function GroupPage() {
+    const { id } = useParams();
+    const [group, setGroup] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [notFound, setNotFound] = useState(false);
+
+    useEffect(() => {
+        async function load() {
+            try {
+                const result = await getGroup(id);
+                if (result === null) {
+                    setNotFound(true);        // AC8: not a member, or no such group
+                } else {
+                    setGroup(result);
+                }
+            } catch (err) {
+                console.error('Failed to load group', err);
+                setError('Could not load this group. Please try again.');
+            } finally {
+                setLoading(false);
+            }
+        }
+        load();
+    }, [id]);
+
+    if (loading) {
+        return <div className="page"><p>Loading…</p></div>;
+    }
+
+    if (notFound) {
+        return (
+            <div className="page">
+                <div className="group-card">
+                    <h1>Group not found</h1>
+                    <p className="empty">This group does not exist, or you are not a member of it.</p>
+                    <Link to="/groups">Back to your groups</Link>
+                </div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="page">
+                <div className="group-card">
+                    <span className="error">{error}</span>
+                    <Link to="/groups">Back to your groups</Link>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="page">
+            <div className="group-card">
+                <h1>{group.name}</h1>
+                {group.description && <p className="subtitle">{group.description}</p>}
+
+                <section>
+                    <h2>Expenses</h2>
+                    {/* AC2: a new group has no expenses */}
+                    <p className="empty">No expenses yet.</p>
+                </section>
+
+                <section>
+                    <h2>Balances</h2>
+                    {/* AC2: all balances are zero until expenses are added */}
+                    <p className="balance">
+                        Everyone is settled up. Balance: {group.baseCurrency} 0.00
+                    </p>
+                </section>
+
+                <Link to="/groups">Back to your groups</Link>
+            </div>
+        </div>
+    );
+}
+
+export default GroupPage;

--- a/frontend/src/pages/GroupsOverview.css
+++ b/frontend/src/pages/GroupsOverview.css
@@ -1,0 +1,42 @@
+.group-list {
+    list-style: none;
+    margin: 0 0 20px;
+    padding: 0;
+}
+
+.group-list li {
+    border-bottom: 1px solid #eee;
+}
+
+.group-list a {
+    display: flex;
+    flex-direction: column;
+    padding: 12px 0;
+    text-decoration: none;
+    color: inherit;
+}
+
+.group-list a:hover {
+    background-color: #fafafa;
+}
+
+.group-name {
+    font-weight: bold;
+    font-size: 16px;
+}
+
+.group-meta {
+    margin-top: 4px;
+    font-size: 14px;
+    color: #666;
+}
+
+.create-link {
+    display: block;
+    padding: 12px;
+    text-align: center;
+    background-color: #eee;
+    border-radius: 5px;
+    text-decoration: none;
+    color: inherit;
+}

--- a/frontend/src/pages/GroupsOverview.jsx
+++ b/frontend/src/pages/GroupsOverview.jsx
@@ -28,7 +28,7 @@ function GroupsOverview() {
 
     return (
         <div className="page">
-            <div className="groups-card">
+            <div className="card">
                 <h1>Your Groups</h1>
 
                 {error && <span className="error">{error}</span>}

--- a/frontend/src/pages/GroupsOverview.jsx
+++ b/frontend/src/pages/GroupsOverview.jsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { getGroups } from '../api/groups';
+import './GroupsOverview.css';
+
+function GroupsOverview() {
+    const [groups, setGroups] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        async function load() {
+            try {
+                setGroups(await getGroups());
+            } catch (err) {
+                console.error('Failed to load groups', err);
+                setError('Could not load your groups. Please try again.');
+            } finally {
+                setLoading(false);
+            }
+        }
+        load();
+    }, []);
+
+    if (loading) {
+        return <div className="page"><p>Loading your groups…</p></div>;
+    }
+
+    return (
+        <div className="page">
+            <div className="groups-card">
+                <h1>Your Groups</h1>
+
+                {error && <span className="error">{error}</span>}
+
+                {!error && groups.length === 0 && (
+                    <p className="empty">You are not in any groups yet.</p>
+                )}
+
+                <ul className="group-list">
+                    {groups.map((group) => (
+                        <li key={group.id}>
+                            <Link to={`/groups/${group.id}`}>
+                                <span className="group-name">{group.name}</span>
+                                <span className="group-meta">
+                  {group.memberCount} {group.memberCount === 1 ? 'member' : 'members'}
+                                    {' · created '}
+                                    {new Date(group.createdAt).toLocaleDateString()}
+                </span>
+                            </Link>
+                        </li>
+                    ))}
+                </ul>
+
+                <Link to="/groups/new" className="create-link">Create group</Link>
+            </div>
+        </div>
+    );
+}
+
+export default GroupsOverview;

--- a/frontend/test/CreateGroup.test.jsx
+++ b/frontend/test/CreateGroup.test.jsx
@@ -61,4 +61,16 @@ describe('CreateGroup', () => {
         expect(await screen.findByText(/at most 50 characters/i)).toBeInTheDocument();
         expect(mockNavigate).not.toHaveBeenCalled();
     });
+
+    it('shows an inline error when the description is too long', async () => {
+        createGroup.mockResolvedValue({
+            errors: { description: 'Description must be at most 255 characters' }
+        });
+
+        renderPage();
+        await userEvent.type(screen.getByLabelText(/group name/i), 'Flat 3');
+        await userEvent.click(screen.getByRole('button', { name: /create group/i }));
+
+        expect(await screen.findByText(/at most 255 characters/i)).toBeInTheDocument();
+    });
 });

--- a/frontend/test/CreateGroup.test.jsx
+++ b/frontend/test/CreateGroup.test.jsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import CreateGroup from '../src/pages/CreateGroup.jsx';
+import { createGroup } from '../src/api/groups';
+
+vi.mock('../src/api/groups', () => ({
+    createGroup: vi.fn(),
+    getGroups: vi.fn(),
+    getGroup: vi.fn(),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => ({
+    ...(await vi.importActual('react-router-dom')),
+    useNavigate: () => mockNavigate,
+}));
+
+function renderPage() {
+    render(
+        <MemoryRouter>
+            <CreateGroup />
+        </MemoryRouter>
+    );
+}
+
+describe('CreateGroup', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('AC1: navigates to the new group page after creation', async () => {
+        createGroup.mockResolvedValue({ group: { id: 7, name: 'Flat 3' } });
+
+        renderPage();
+        await userEvent.type(screen.getByLabelText(/group name/i), 'Flat 3');
+        await userEvent.click(screen.getByRole('button', { name: /create group/i }));
+
+        expect(mockNavigate).toHaveBeenCalledWith('/groups/7');
+    });
+
+    it('AC3: shows an inline error when the name is rejected as blank', async () => {
+        createGroup.mockResolvedValue({ errors: { name: 'Group name is required' } });
+
+        renderPage();
+        await userEvent.type(screen.getByLabelText(/group name/i), '   ');
+        await userEvent.click(screen.getByRole('button', { name: /create group/i }));
+
+        expect(await screen.findByText('Group name is required')).toBeInTheDocument();
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('AC4: shows an inline error when the name is too long', async () => {
+        createGroup.mockResolvedValue({ errors: { name: 'Group name must be at most 50 characters' } });
+
+        renderPage();
+        await userEvent.type(screen.getByLabelText(/group name/i), 'a'.repeat(51));
+        await userEvent.click(screen.getByRole('button', { name: /create group/i }));
+
+        expect(await screen.findByText(/at most 50 characters/i)).toBeInTheDocument();
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/test/GroupPage.test.jsx
+++ b/frontend/test/GroupPage.test.jsx
@@ -1,0 +1,51 @@
+import { it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import GroupPage from '../src/pages/GroupPage.jsx';
+import { getGroup } from '../src/api/groups';
+
+vi.mock('../src/api/groups', () => ({
+    createGroup: vi.fn(),
+    getGroups: vi.fn(),
+    getGroup: vi.fn(),
+}));
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+function renderPage() {
+    render(
+        <MemoryRouter initialEntries={['/groups/1']}>
+            <Routes>
+                <Route path="/groups/:id" element={<GroupPage />} />
+            </Routes>
+        </MemoryRouter>
+    );
+}
+
+it('AC2: a new group lists no expenses and shows zero balances', async () => {
+    getGroup.mockResolvedValue({
+        id: 1,
+        name: 'Flat 3',
+        description: null,
+        baseCurrency: 'NZD',
+        createdAt: '2026-08-16T00:00:00Z',
+        memberCount: 1,
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Flat 3')).toBeInTheDocument();
+    expect(screen.getByText('No expenses yet.')).toBeInTheDocument();
+    expect(screen.getByText(/NZD 0\.00/)).toBeInTheDocument();
+});
+
+it('AC8: shows a not-found message when the user is not a member', async () => {
+    getGroup.mockResolvedValue(null);
+
+    renderPage();
+
+    expect(await screen.findByText('Group not found')).toBeInTheDocument();
+    expect(screen.queryByText('No expenses yet.')).not.toBeInTheDocument();
+});

--- a/frontend/test/GroupsOverview.test.jsx
+++ b/frontend/test/GroupsOverview.test.jsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import GroupsOverview from '../src/pages/GroupsOverview.jsx';
+import { getGroups } from '../src/api/groups';
+
+vi.mock('../src/api/groups', () => ({
+    createGroup: vi.fn(),
+    getGroups: vi.fn(),
+    getGroup: vi.fn(),
+}));
+
+function renderPage() {
+    render(
+        <MemoryRouter>
+            <GroupsOverview />
+        </MemoryRouter>
+    );
+}
+
+describe('GroupsOverview', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('AC5: lists each group by name and links to its page', async () => {
+        getGroups.mockResolvedValue([
+            { id: 1, name: 'Flat 3', baseCurrency: 'NZD', createdAt: '2026-08-16T00:00:00Z', memberCount: 3 },
+            { id: 2, name: 'Ski trip', baseCurrency: 'NZD', createdAt: '2026-08-15T00:00:00Z', memberCount: 5 },
+        ]);
+
+        renderPage();
+
+        expect(await screen.findByText('Flat 3')).toBeInTheDocument();
+        expect(screen.getByText('Ski trip')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /Flat 3/ })).toHaveAttribute('href', '/groups/1');
+        expect(screen.getByRole('link', { name: /Ski trip/ })).toHaveAttribute('href', '/groups/2');
+    });
+
+    it('AC6: shows enough detail to tell two groups with the same name apart', async () => {
+        getGroups.mockResolvedValue([
+            { id: 1, name: 'Trip', baseCurrency: 'NZD', createdAt: '2026-08-16T00:00:00Z', memberCount: 2 },
+            { id: 2, name: 'Trip', baseCurrency: 'NZD', createdAt: '2026-01-02T00:00:00Z', memberCount: 6 },
+        ]);
+
+        renderPage();
+
+        expect(await screen.findAllByText('Trip')).toHaveLength(2);
+
+        const links = screen.getAllByRole('link', { name: /Trip/ });
+        expect(links[0]).toHaveAttribute('href', '/groups/1');
+        expect(links[1]).toHaveAttribute('href', '/groups/2');
+        expect(links[0].textContent).not.toEqual(links[1].textContent);
+    });
+
+    it('shows an empty state when the user has no groups', async () => {
+        getGroups.mockResolvedValue([]);
+
+        renderPage();
+
+        expect(await screen.findByText(/not in any groups yet/i)).toBeInTheDocument();
+    });
+});

--- a/frontend/test/setupTests.js
+++ b/frontend/test/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,4 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './test/setupTests.js'
+  }
 });


### PR DESCRIPTION
## Summary

* add `V2__create_groups_table.sql` creating `expense_group` and `user_in_group`, with `group_name` deliberately not unique so duplicate group names are allowed (AC6)
* add `ExpenseGroup` and `UserInGroup` JPA entities, with the creator added as a member on construction and prevented from leaving
* add `getId()` to `User` and scope all group reads by membership in `ExpenseGroupRepository` (AC8)
* add `ExpenseGroupService`, `ExpenseGroupController`, and request/response DTOs for creating, listing, and fetching groups
* add `GlobalExceptionHandler` returning field-keyed validation errors so the frontend can render them inline (AC3, AC4)
* add `spring-boot-starter-validation`, which is required for `@Valid` to take effect
* move the security filter chain out of `AppConfig` into `SecurityConfig` (`@Profile("!dev")`) and add `DevSecurityConfig` (`@Profile("dev")`), because Spring Security 7 rejects two chains matching any request
* add a temporary `CurrentUserProvider` seam with a stub implementation so group creation can be built before authentication exists
* add `ExpenseGroupServiceIntegrationTest` and a test-only migration seeding two users

## Testing

* `.\mvnw.cmd --batch-mode clean verify` - passed locally with Docker
* AC1, AC5, AC6, AC8 covered by integration tests against MySQL Testcontainers
* AC3, AC4 verified manually over HTTP; automated coverage follows in the frontend PR
* GitHub Actions CI - passed
* SonarCloud Code Analysis - passes apart from the pre-existing CSRF warning noted below
* Snyk PR check - passed

## Notes

* AC7 (unauthenticated access is blocked) is deferred to [UPCOMING AUTH-ISSUE ONCE APPROVED BY GROUP], since no authentication mechanism exists yet. `AppConfig` currently leaves every endpoint except `/users/register` unreachable, which that issue also needs to address.
* AC2 and the navigation parts of AC1 and AC5 are frontend work and follow in a second PR against this issue.
* `UserRepository` and `UserService` are still in the root package rather than `repository` and `service`; worth aligning in a follow-up.
* * SonarCloud flags `csrf.disable()` (java:S4502) in both security chains. This is inherited from the original `AppConfig` implementation, not introduced here — the call was simply moved into the new files. Whether CSRF protection is needed depends on the authentication approach (a real hole with session cookies, not an issue with a bearer token), so the decision belongs with [UPCOMING AUTH-ISSUE ONCE APPROVED BY GROUP].

Closes #3 

## Acknowledgement

Generative AI assisted with implementation planning, schema and entity design, and test scaffolding. The migration, code, security configuration, and verification results were manually reviewed and tested locally.