### PR TITLE
Bump Logback to 1.5.36 to resolve CVE-2026-13006

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -19,6 +19,8 @@
 
     <properties>
         <java.version>21</java.version>
+        <!-- Overrides the Boot-managed 1.5.34, which is affected by CVE-2026-13006. -->
+        <logback.version>1.5.36</logback.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Closes #32

Snyk flags `ch.qos.logback:logback-core@1.5.34` for CVE-2026-13006, an expression injection in Janino-evaluated conditional logging config. Logback is not declared directly, it arrives transitively through `spring-boot-starter-webmvc` with the version pinned by Boot 4.1.0.

## Fix

Boot's BOM resolves both logback modules from the `logback.version` property, so overriding that property in `backend/pom.xml` upgrades `logback-classic` and `logback-core` together. Pinning a single module instead would leave the two on different versions.

Resolution via `./mvnw dependency:tree -Dincludes=ch.qos.logback`:

- before: `logback-classic:1.5.34` → `logback-core:1.5.34`
- after: `logback-classic:1.5.36` → `logback-core:1.5.36`

No application code changed.

## Testing

`./mvnw clean verify` passes, 9 tests, 0 failures, running against 1.5.36.

To verify the fix locally:

    ./mvnw dependency:tree -Dincludes=ch.qos.logback
    ./mvnw clean verify