### PR TITLE
Add expenses with an equal default split

### DIFF
--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/controller/ExpenseController.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/controller/ExpenseController.java
@@ -1,0 +1,39 @@
+package nz.ac.auckland.se310.fairshare.controller;
+
+import jakarta.validation.Valid;
+import nz.ac.auckland.se310.fairshare.dto.CreateExpenseRequest;
+import nz.ac.auckland.se310.fairshare.dto.ExpenseResponse;
+import nz.ac.auckland.se310.fairshare.security.CurrentUserProvider;
+import nz.ac.auckland.se310.fairshare.service.ExpenseService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/groups/{groupId}/expenses")
+public class ExpenseController {
+
+    private final ExpenseService expenseService;
+    private final CurrentUserProvider currentUser;
+
+    public ExpenseController(ExpenseService expenseService, CurrentUserProvider currentUser) {
+        this.expenseService = expenseService;
+        this.currentUser = currentUser;
+    }
+
+    @PostMapping
+    public ResponseEntity<ExpenseResponse> create(@PathVariable Long groupId,
+                                                    @Valid @RequestBody CreateExpenseRequest request) {
+        ExpenseResponse created = expenseService.createExpense(groupId, request, currentUser.currentUserId());
+        return ResponseEntity
+                .created(URI.create("/groups/" + groupId + "/expenses/" + created.id()))
+                .body(created);
+    }
+
+    @GetMapping
+    public List<ExpenseResponse> list(@PathVariable Long groupId) {
+        return expenseService.getExpensesForGroup(groupId, currentUser.currentUserId());
+    }
+}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/dto/CreateExpenseRequest.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/dto/CreateExpenseRequest.java
@@ -1,0 +1,25 @@
+package nz.ac.auckland.se310.fairshare.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record CreateExpenseRequest(
+        @NotNull(message = "Amount is required")
+        @Positive(message = "Amount must be a positive number")
+        BigDecimal amount,
+
+        @NotBlank(message = "Description is required")
+        @Size(max = 255, message = "Description must be at most 255 characters")
+        String description,
+
+        @NotNull(message = "Payer is required")
+        Long paidByUserId,
+
+        @PastOrPresent(message = "Expense date cannot be in the future")
+        LocalDate expenseDate) {}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/dto/CreateExpenseRequest.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/dto/CreateExpenseRequest.java
@@ -1,5 +1,6 @@
 package nz.ac.auckland.se310.fairshare.dto;
 
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
@@ -12,6 +13,8 @@ import java.time.LocalDate;
 public record CreateExpenseRequest(
         @NotNull(message = "Amount is required")
         @Positive(message = "Amount must be a positive number")
+        // Amounts are stored to the cent, so anything under one cent would round away to 0.00.
+        @DecimalMin(value = "0.01", message = "Amount must be at least 0.01")
         BigDecimal amount,
 
         @NotBlank(message = "Description is required")

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/dto/ExpenseResponse.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/dto/ExpenseResponse.java
@@ -1,0 +1,9 @@
+package nz.ac.auckland.se310.fairshare.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+
+public record ExpenseResponse(
+        Long id, Long groupId, Long paidByUserId, String paidByUsername,
+        BigDecimal amount, String description, LocalDate expenseDate, Instant createdAt) {}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/exception/GlobalExceptionHandler.java
@@ -12,6 +12,8 @@ import java.util.Map;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private static final String ERROR_KEY = "error";
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleValidation(MethodArgumentNotValidException ex) {
         Map<String, String> errors = new HashMap<>();
@@ -23,27 +25,33 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(GroupNotFoundException.class)
     public ResponseEntity<Map<String, String>> handleGroupNotFound(GroupNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(Map.of("error", "Group not found"));
+                .body(Map.of(ERROR_KEY, "Group not found"));
     }
 
     @ExceptionHandler(GroupAccessDeniedException.class)
     public ResponseEntity<Map<String, String>> handleGroupAccessDenied(
             GroupAccessDeniedException ex) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                .body(Map.of("error", ex.getMessage()));
+                .body(Map.of(ERROR_KEY, ex.getMessage()));
     }
 
     @ExceptionHandler(GroupMemberNotFoundException.class)
     public ResponseEntity<Map<String, String>> handleGroupMemberNotFound(
             GroupMemberNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(Map.of("error", ex.getMessage()));
+                .body(Map.of(ERROR_KEY, ex.getMessage()));
     }
 
     @ExceptionHandler(GroupMemberConflictException.class)
     public ResponseEntity<Map<String, String>> handleGroupMemberConflict(
             GroupMemberConflictException ex) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(Map.of("error", ex.getMessage()));
+                .body(Map.of(ERROR_KEY, ex.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidPayerException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidPayer(InvalidPayerException ex) {
+        return ResponseEntity.badRequest()
+                .body(Map.of(ERROR_KEY, "Payer must be a member of the group"));
     }
 }

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/exception/InvalidPayerException.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/exception/InvalidPayerException.java
@@ -1,0 +1,8 @@
+package nz.ac.auckland.se310.fairshare.exception;
+
+public class InvalidPayerException extends RuntimeException {
+
+    public InvalidPayerException(Long userId) {
+        super("Payer is not a member of the group: " + userId);
+    }
+}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/model/Expense.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/model/Expense.java
@@ -1,0 +1,68 @@
+package nz.ac.auckland.se310.fairshare.model;
+
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "expense")
+public class Expense {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "expense_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "group_id", nullable = false, updatable = false)
+    private ExpenseGroup group;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "paid_by", nullable = false, updatable = false)
+    private User paidBy;
+
+    @Column(name = "amount", nullable = false, precision = 10, scale = 2)
+    private BigDecimal amount;
+
+    @Column(name = "description", nullable = false, length = 255)
+    private String description;
+
+    @Column(name = "expense_date", nullable = false)
+    private LocalDate expenseDate;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    protected Expense() {} // JPA
+
+    public Expense(ExpenseGroup group, User paidBy, BigDecimal amount, String description, LocalDate expenseDate) {
+        this.group = group;
+        this.paidBy = paidBy;
+        this.amount = amount;
+        this.description = description;
+        this.expenseDate = expenseDate;
+        this.createdAt = Instant.now();
+    }
+
+    public Long getId() { return id; }
+    public ExpenseGroup getGroup() { return group; }
+    public User getPaidBy() { return paidBy; }
+    public BigDecimal getAmount() { return amount; }
+    public String getDescription() { return description; }
+    public LocalDate getExpenseDate() { return expenseDate; }
+    public Instant getCreatedAt() { return createdAt; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Expense other)) return false;
+        return id != null && id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/model/UserInGroup.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/model/UserInGroup.java
@@ -44,6 +44,11 @@ public class UserInGroup {
         return netBalance.compareTo(BigDecimal.ZERO) != 0;
     }
 
+    // Positive means the member is owed, negative means they owe.
+    public void adjustNetBalance(BigDecimal delta) {
+        this.netBalance = this.netBalance.add(delta).setScale(2);
+    }
+
     @Override
     public boolean equals(Object object) {
         if (this == object) return true;

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/repository/ExpenseRepository.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/repository/ExpenseRepository.java
@@ -1,0 +1,12 @@
+package nz.ac.auckland.se310.fairshare.repository;
+
+import nz.ac.auckland.se310.fairshare.model.Expense;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+
+    // AC7: newest first for the group's expense list
+    List<Expense> findByGroupIdOrderByExpenseDateDesc(Long groupId);
+}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/service/ExpenseService.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/service/ExpenseService.java
@@ -1,0 +1,104 @@
+package nz.ac.auckland.se310.fairshare.service;
+
+import nz.ac.auckland.se310.fairshare.dto.CreateExpenseRequest;
+import nz.ac.auckland.se310.fairshare.dto.ExpenseResponse;
+import nz.ac.auckland.se310.fairshare.exception.GroupAccessDeniedException;
+import nz.ac.auckland.se310.fairshare.exception.InvalidPayerException;
+import nz.ac.auckland.se310.fairshare.model.Expense;
+import nz.ac.auckland.se310.fairshare.model.ExpenseGroup;
+import nz.ac.auckland.se310.fairshare.model.UserInGroup;
+import nz.ac.auckland.se310.fairshare.repository.ExpenseRepository;
+import nz.ac.auckland.se310.fairshare.repository.ExpenseGroupRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+public class ExpenseService {
+
+    private static final int MONEY_SCALE = 2;
+
+    private final ExpenseRepository expenseRepository;
+    private final ExpenseGroupRepository groupRepository;
+
+    public ExpenseService(ExpenseRepository expenseRepository, ExpenseGroupRepository groupRepository) {
+        this.expenseRepository = expenseRepository;
+        this.groupRepository = groupRepository;
+    }
+
+    @Transactional
+    public ExpenseResponse createExpense(Long groupId, CreateExpenseRequest request, Long currentUserId) {
+        ExpenseGroup group = groupRepository.findByIdAndMembersUserId(groupId, currentUserId)
+                .orElseThrow(GroupAccessDeniedException::new); // AC8
+
+        UserInGroup payer = group.getMember(request.paidByUserId());
+        if (payer == null) {
+            throw new InvalidPayerException(request.paidByUserId()); // AC5
+        }
+
+        BigDecimal amount = request.amount().setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+        LocalDate expenseDate = request.expenseDate() != null ? request.expenseDate() : LocalDate.now(); // AC6
+
+        Expense expense = new Expense(
+                group, payer.getUser(), amount, request.description().trim(), expenseDate);
+        Expense saved = expenseRepository.save(expense);
+
+        applyEqualSplit(group, payer, amount); // AC1, AC4
+
+        return toResponse(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ExpenseResponse> getExpensesForGroup(Long groupId, Long currentUserId) {
+        groupRepository.findByIdAndMembersUserId(groupId, currentUserId)
+                .orElseThrow(GroupAccessDeniedException::new); // AC8
+
+        return expenseRepository.findByGroupIdOrderByExpenseDateDesc(groupId)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    /**
+     * AC4: the amount is split equally across every current member. Cents left over by an
+     * uneven division go to the lowest user ids, so the shares always add back up to the
+     * amount the payer actually spent.
+     */
+    private void applyEqualSplit(ExpenseGroup group, UserInGroup payer, BigDecimal amount) {
+        List<UserInGroup> members = group.getMembers().stream()
+                .sorted(Comparator.comparing(member -> member.getUser().getId()))
+                .toList();
+
+        long totalCents = amount.movePointRight(MONEY_SCALE).longValueExact();
+        long baseShare = totalCents / members.size();
+        long extraCents = totalCents % members.size();
+
+        payer.adjustNetBalance(amount);
+
+        for (int i = 0; i < members.size(); i++) {
+            long shareCents = baseShare + (i < extraCents ? 1 : 0);
+            members.get(i).adjustNetBalance(cents(-shareCents));
+        }
+    }
+
+    private BigDecimal cents(long value) {
+        return BigDecimal.valueOf(value, MONEY_SCALE);
+    }
+
+    private ExpenseResponse toResponse(Expense expense) {
+        return new ExpenseResponse(
+                expense.getId(),
+                expense.getGroup().getId(),
+                expense.getPaidBy().getId(),
+                expense.getPaidBy().getUsername(),
+                expense.getAmount(),
+                expense.getDescription(),
+                expense.getExpenseDate(),
+                expense.getCreatedAt());
+    }
+}

--- a/backend/src/main/resources/db/migration/V4__create_expenses_table.sql
+++ b/backend/src/main/resources/db/migration/V4__create_expenses_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE expense (
+    expense_id   BIGINT AUTO_INCREMENT PRIMARY KEY,
+    group_id     BIGINT       NOT NULL,
+    paid_by      BIGINT       NOT NULL,
+    amount       DECIMAL(10,2) NOT NULL,
+    description  VARCHAR(255) NOT NULL,
+    expense_date DATE         NOT NULL,
+    created_at   TIMESTAMP    NOT NULL,
+    CONSTRAINT fk_expense_group
+        FOREIGN KEY (group_id) REFERENCES expense_group (group_id),
+    CONSTRAINT fk_expense_paid_by
+        FOREIGN KEY (paid_by) REFERENCES users (id)
+);

--- a/backend/src/test/java/nz/ac/auckland/se310/fairshare/ExpenseIntegrationTest.java
+++ b/backend/src/test/java/nz/ac/auckland/se310/fairshare/ExpenseIntegrationTest.java
@@ -1,0 +1,219 @@
+package nz.ac.auckland.se310.fairshare;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import nz.ac.auckland.se310.fairshare.dto.CreateExpenseRequest;
+import nz.ac.auckland.se310.fairshare.dto.CreateGroupRequest;
+import nz.ac.auckland.se310.fairshare.dto.ExpenseResponse;
+import nz.ac.auckland.se310.fairshare.dto.GroupMemberResponse;
+import nz.ac.auckland.se310.fairshare.exception.GroupAccessDeniedException;
+import nz.ac.auckland.se310.fairshare.exception.InvalidPayerException;
+import nz.ac.auckland.se310.fairshare.model.User;
+import nz.ac.auckland.se310.fairshare.repository.ExpenseGroupRepository;
+import nz.ac.auckland.se310.fairshare.repository.ExpenseRepository;
+import nz.ac.auckland.se310.fairshare.service.ExpenseGroupService;
+import nz.ac.auckland.se310.fairshare.service.ExpenseService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mysql.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Import(TestCurrentUserConfig.class)
+class ExpenseIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static final MySQLContainer MYSQL = new MySQLContainer(DockerImageName.parse("mysql:8.4"));
+
+    private static final String CAROL_EMAIL = "carol@test.com";
+    private static final String AMOUNT_FIELD = "amount";
+    private static final String GROCERIES = "Groceries";
+    private static final String GROCERIES_AMOUNT = "42.50";
+    private static final String TAXI_AMOUNT = "10.00";
+
+    @Autowired ExpenseGroupService groupService;
+    @Autowired ExpenseService expenseService;
+    @Autowired ExpenseGroupRepository groupRepository;
+    @Autowired ExpenseRepository expenseRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired Validator validator;
+
+    private Long aliceId;
+    private Long bobId;
+    private Long carolId;
+    private Long groupId;
+
+    @BeforeEach
+    void setUp() {
+        expenseRepository.deleteAll();
+        groupRepository.deleteAll();
+
+        aliceId = userRepository.findByEmail("alice@test.com").orElseThrow().getId();
+        bobId = userRepository.findByEmail("bob@test.com").orElseThrow().getId();
+        carolId = userRepository.findByEmail(CAROL_EMAIL)
+                .orElseGet(() -> userRepository.save(new User(
+                        "carol", "x", CAROL_EMAIL, User.Country.NEW_ZEALAND, User.Currency.NZD)))
+                .getId();
+
+        groupId = groupService.createGroup(new CreateGroupRequest("Flat 3", null), aliceId).id();
+        groupService.addMember(groupId, "bob@test.com", aliceId);
+    }
+
+    @Test
+    void ac1_createsExpenseWithGivenDetails() {
+        var request = new CreateExpenseRequest(
+                new BigDecimal(GROCERIES_AMOUNT), GROCERIES, bobId, LocalDate.of(2026, Month.AUGUST, 1));
+
+        ExpenseResponse created = expenseService.createExpense(groupId, request, aliceId);
+
+        assertThat(created.id()).isNotNull();
+        assertThat(created.groupId()).isEqualTo(groupId);
+        assertThat(created.amount()).isEqualByComparingTo(GROCERIES_AMOUNT);
+        assertThat(created.description()).isEqualTo(GROCERIES);
+        assertThat(created.paidByUserId()).isEqualTo(bobId);
+        assertThat(created.paidByUsername()).isEqualTo("bob");
+        assertThat(created.expenseDate()).isEqualTo(LocalDate.of(2026, Month.AUGUST, 1));
+        assertThat(expenseRepository.findById(created.id())).isPresent();
+    }
+
+    @Test
+    void ac1_balancesReflectTheNewExpense() {
+        var request = new CreateExpenseRequest(new BigDecimal(GROCERIES_AMOUNT), GROCERIES, bobId, null);
+
+        expenseService.createExpense(groupId, request, aliceId);
+
+        assertThat(balances()).containsOnly(
+                Map.entry(bobId, new BigDecimal("21.25")),
+                Map.entry(aliceId, new BigDecimal("-21.25")));
+    }
+
+    @Test
+    void ac2AndAc3_rejectsMissingFieldsAndNonPositiveAmounts() {
+        assertThat(violations(new CreateExpenseRequest(null, "  ", null, null)))
+                .containsOnlyKeys(AMOUNT_FIELD, "description", "paidByUserId");
+
+        assertThat(violations(new CreateExpenseRequest(BigDecimal.ZERO, "Taxi", aliceId, null)))
+                .containsEntry(AMOUNT_FIELD, "Amount must be a positive number");
+
+        assertThat(violations(new CreateExpenseRequest(new BigDecimal("-5.00"), "Taxi", aliceId, null)))
+                .containsEntry(AMOUNT_FIELD, "Amount must be a positive number");
+    }
+
+    @Test
+    void ac4_splitsEquallyAcrossAllCurrentMembers() {
+        groupService.addMember(groupId, CAROL_EMAIL, aliceId);
+
+        var request = new CreateExpenseRequest(new BigDecimal("90.00"), "Power bill", aliceId, null);
+
+        expenseService.createExpense(groupId, request, aliceId);
+
+        assertThat(balances()).containsOnly(
+                Map.entry(aliceId, new BigDecimal("60.00")),
+                Map.entry(bobId, new BigDecimal("-30.00")),
+                Map.entry(carolId, new BigDecimal("-30.00")));
+    }
+
+    @Test
+    void ac4_unevenSplitStillSumsToTheAmount() {
+        groupService.addMember(groupId, CAROL_EMAIL, aliceId);
+
+        var request = new CreateExpenseRequest(new BigDecimal("100.00"), "Internet", aliceId, null);
+
+        expenseService.createExpense(groupId, request, aliceId);
+
+        // The extra cent goes to the lowest user id, so the shares add back up to 100.00.
+        assertThat(balances()).containsOnly(
+                Map.entry(aliceId, new BigDecimal("66.66")),
+                Map.entry(bobId, new BigDecimal("-33.33")),
+                Map.entry(carolId, new BigDecimal("-33.33")));
+        assertThat(balances().values().stream().reduce(BigDecimal.ZERO, BigDecimal::add))
+                .isEqualByComparingTo("0.00");
+    }
+
+    @Test
+    void ac5_payerMustBeAGroupMember() {
+        var request = new CreateExpenseRequest(new BigDecimal(TAXI_AMOUNT), "Taxi", carolId, null);
+
+        assertThatThrownBy(() -> expenseService.createExpense(groupId, request, aliceId))
+                .isInstanceOf(InvalidPayerException.class);
+    }
+
+    @Test
+    void ac6_expenseDateDefaultsToTodayWhenOmitted() {
+        var request = new CreateExpenseRequest(new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, null);
+
+        ExpenseResponse created = expenseService.createExpense(groupId, request, aliceId);
+
+        assertThat(created.expenseDate()).isEqualTo(LocalDate.now());
+    }
+
+    @Test
+    void ac6_rejectsAFutureDateAndAcceptsAPastOne() {
+        assertThat(violations(new CreateExpenseRequest(
+                new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, LocalDate.now().plusDays(1))))
+                .containsEntry("expenseDate", "Expense date cannot be in the future");
+
+        assertThat(violations(new CreateExpenseRequest(
+                new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, LocalDate.now().minusDays(30))))
+                .isEmpty();
+    }
+
+    @Test
+    void ac7_listsGroupExpensesForEveryMemberNewestFirst() {
+        expenseService.createExpense(groupId, new CreateExpenseRequest(
+                new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, LocalDate.now().minusDays(3)), aliceId);
+        expenseService.createExpense(groupId, new CreateExpenseRequest(
+                new BigDecimal("20.00"), "Pizza", bobId, LocalDate.now().minusDays(1)), aliceId);
+
+        List<ExpenseResponse> expenses = expenseService.getExpensesForGroup(groupId, bobId);
+
+        assertThat(expenses)
+                .extracting(ExpenseResponse::description)
+                .containsExactly("Pizza", "Taxi");
+        assertThat(expenses.getFirst().paidByUsername()).isEqualTo("bob");
+        assertThat(expenses.getFirst().amount()).isEqualByComparingTo("20.00");
+        assertThat(expenses.getFirst().expenseDate()).isEqualTo(LocalDate.now().minusDays(1));
+    }
+
+    @Test
+    void ac8_nonMemberCannotCreateOrViewExpenses() {
+        var request = new CreateExpenseRequest(new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, null);
+
+        assertThatThrownBy(() -> expenseService.createExpense(groupId, request, carolId))
+                .isInstanceOf(GroupAccessDeniedException.class);
+        assertThatThrownBy(() -> expenseService.getExpensesForGroup(groupId, carolId))
+                .isInstanceOf(GroupAccessDeniedException.class);
+    }
+
+    private Map<Long, BigDecimal> balances() {
+        return groupService.getMembers(groupId, aliceId).stream()
+                .collect(Collectors.toMap(
+                        GroupMemberResponse::userId, GroupMemberResponse::netBalance));
+    }
+
+    private Map<String, String> violations(CreateExpenseRequest request) {
+        return validator.validate(request).stream()
+                .collect(Collectors.toMap(
+                        violation -> violation.getPropertyPath().toString(),
+                        ConstraintViolation::getMessage,
+                        (first, second) -> first));
+    }
+}

--- a/backend/src/test/java/nz/ac/auckland/se310/fairshare/ExpenseIntegrationTest.java
+++ b/backend/src/test/java/nz/ac/auckland/se310/fairshare/ExpenseIntegrationTest.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
@@ -111,10 +112,19 @@ class ExpenseIntegrationTest {
                 .containsOnlyKeys(AMOUNT_FIELD, "description", "paidByUserId");
 
         assertThat(violations(new CreateExpenseRequest(BigDecimal.ZERO, "Taxi", aliceId, null)))
-                .containsEntry(AMOUNT_FIELD, "Amount must be a positive number");
+                .extractingByKey(AMOUNT_FIELD, list(String.class))
+                .contains("Amount must be a positive number");
 
         assertThat(violations(new CreateExpenseRequest(new BigDecimal("-5.00"), "Taxi", aliceId, null)))
-                .containsEntry(AMOUNT_FIELD, "Amount must be a positive number");
+                .extractingByKey(AMOUNT_FIELD, list(String.class))
+                .contains("Amount must be a positive number");
+    }
+
+    @Test
+    void ac3_rejectsAmountsSmallerThanOneCent() {
+        assertThat(violations(new CreateExpenseRequest(new BigDecimal("0.004"), "Taxi", aliceId, null)))
+                .extractingByKey(AMOUNT_FIELD, list(String.class))
+                .containsExactly("Amount must be at least 0.01");
     }
 
     @Test
@@ -169,7 +179,8 @@ class ExpenseIntegrationTest {
     void ac6_rejectsAFutureDateAndAcceptsAPastOne() {
         assertThat(violations(new CreateExpenseRequest(
                 new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, LocalDate.now().plusDays(1))))
-                .containsEntry("expenseDate", "Expense date cannot be in the future");
+                .extractingByKey("expenseDate", list(String.class))
+                .containsExactly("Expense date cannot be in the future");
 
         assertThat(violations(new CreateExpenseRequest(
                 new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, LocalDate.now().minusDays(30))))
@@ -209,11 +220,11 @@ class ExpenseIntegrationTest {
                         GroupMemberResponse::userId, GroupMemberResponse::netBalance));
     }
 
-    private Map<String, String> violations(CreateExpenseRequest request) {
+    /** A field can break more than one constraint at a time, so every message is kept. */
+    private Map<String, List<String>> violations(CreateExpenseRequest request) {
         return validator.validate(request).stream()
-                .collect(Collectors.toMap(
+                .collect(Collectors.groupingBy(
                         violation -> violation.getPropertyPath().toString(),
-                        ConstraintViolation::getMessage,
-                        (first, second) -> first));
+                        Collectors.mapping(ConstraintViolation::getMessage, Collectors.toList())));
     }
 }

--- a/frontend/src/api/expenses.js
+++ b/frontend/src/api/expenses.js
@@ -21,9 +21,11 @@ export async function createExpense(id, expense) {
         body: JSON.stringify(expense)
     });
 
-    // AC2, AC3, AC6: the backend returns one message per invalid field.
     if (response.status === 400) {
-        return { errors: await response.json() };
+        const body = await response.json();
+        // AC2, AC3, AC6 come back keyed by field. A rejection that belongs to no single
+        // field, such as a payer who has left the group, comes back under "error".
+        return { errors: body.error ? { form: body.error } : body };
     }
     if (!response.ok) {
         return { errors: { form: await readError(response, 'Could not add this expense.') } };

--- a/frontend/src/api/expenses.js
+++ b/frontend/src/api/expenses.js
@@ -1,0 +1,32 @@
+import { API_BASE } from './config.js';
+import { readError, requirePositiveInteger } from './groups.js';
+
+export async function getExpenses(id) {
+    const groupId = requirePositiveInteger(id, 'Group ID');
+    const response = await fetch(`${API_BASE}/groups/${groupId}/expenses`, {
+        credentials: 'include'
+    });
+    if (!response.ok) {
+        return { error: await readError(response, 'Could not load expenses.') };
+    }
+    return { expenses: await response.json() };
+}
+
+export async function createExpense(id, expense) {
+    const groupId = requirePositiveInteger(id, 'Group ID');
+    const response = await fetch(`${API_BASE}/groups/${groupId}/expenses`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(expense)
+    });
+
+    // AC2, AC3, AC6: the backend returns one message per invalid field.
+    if (response.status === 400) {
+        return { errors: await response.json() };
+    }
+    if (!response.ok) {
+        return { errors: { form: await readError(response, 'Could not add this expense.') } };
+    }
+    return { expense: await response.json() };
+}

--- a/frontend/src/api/groups.js
+++ b/frontend/src/api/groups.js
@@ -1,6 +1,6 @@
 import {API_BASE} from "./config.js";
 
-async function readError(response, fallback) {
+export async function readError(response, fallback) {
     try {
         const body = await response.json();
         return body.error || Object.values(body)[0] || fallback;
@@ -9,7 +9,7 @@ async function readError(response, fallback) {
     }
 }
 
-function requirePositiveInteger(value, label) {
+export function requirePositiveInteger(value, label) {
     const text = String(value);
     if (!/^[1-9]\d*$/.test(text)) {
         throw new TypeError(`${label} must be a positive integer`);

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -7,6 +7,7 @@ import CreateGroup from './pages/CreateGroup.jsx';
 import GroupPage from './pages/GroupPage.jsx';
 import Landing from './pages/Landing.jsx';
 import GroupMembers from './pages/GroupMembers.jsx';
+import AddExpense from './pages/AddExpense.jsx';
 import Login from './pages/Login.jsx';
 import UserManagement from './pages/UserManagement.jsx';
 import './index.css';
@@ -48,6 +49,10 @@ const router = createBrowserRouter([
             {
                 path: '/groups/:id/members',
                 element: <GroupMembers/>
+            },
+            {
+                path: '/groups/:id/expenses/new',
+                element: <AddExpense/>,
             }
         ]
     }

--- a/frontend/src/pages/AddExpense.css
+++ b/frontend/src/pages/AddExpense.css
@@ -1,0 +1,8 @@
+.form-group select {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    font-size: 14px;
+    background: #fff;
+}

--- a/frontend/src/pages/AddExpense.jsx
+++ b/frontend/src/pages/AddExpense.jsx
@@ -4,8 +4,13 @@ import { getGroupMembers } from '../api/groups';
 import { createExpense } from '../api/expenses';
 import './AddExpense.css';
 
+// Built from local date because toISOString() reports the UTC date and
+// would give yesterday for the first hours of a New Zealand day.
 function today() {
-    return new Date().toISOString().slice(0, 10);
+    const now = new Date();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    return `${now.getFullYear()}-${month}-${day}`;
 }
 
 function validate({ amount, description, paidByUserId, expenseDate }) {

--- a/frontend/src/pages/AddExpense.jsx
+++ b/frontend/src/pages/AddExpense.jsx
@@ -1,0 +1,177 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { getGroupMembers } from '../api/groups';
+import { createExpense } from '../api/expenses';
+import './AddExpense.css';
+
+function today() {
+    return new Date().toISOString().slice(0, 10);
+}
+
+function validate({ amount, description, paidByUserId, expenseDate }) {
+    const errors = {};
+
+    if (amount.trim() === '') {
+        errors.amount = 'Amount is required';                          // AC2
+    } else if (!(Number(amount) > 0)) {
+        errors.amount = 'Amount must be a positive number';            // AC3
+    }
+
+    if (description.trim() === '') {
+        errors.description = 'Description is required';                // AC2
+    }
+
+    if (paidByUserId === '') {
+        errors.paidByUserId = 'Payer is required';                     // AC2
+    }
+
+    if (expenseDate > today()) {
+        errors.expenseDate = 'Expense date cannot be in the future';   // AC6
+    }
+
+    return errors;
+}
+
+function AddExpense() {
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const [members, setMembers] = useState([]);
+    const [amount, setAmount] = useState('');
+    const [description, setDescription] = useState('');
+    const [paidByUserId, setPaidByUserId] = useState('');
+    const [expenseDate, setExpenseDate] = useState(today());   // AC6
+    const [loading, setLoading] = useState(true);
+    const [submitting, setSubmitting] = useState(false);
+    const [errors, setErrors] = useState({});
+
+    useEffect(() => {
+        async function loadMembers() {
+            const result = await getGroupMembers(id);
+            if (result.error) {
+                setErrors({ form: result.error });                     // AC8
+            } else {
+                setMembers(result.members);                            // AC5
+                const self = result.members.find((member) => member.currentUser);
+                setPaidByUserId(String((self ?? result.members[0])?.userId ?? ''));
+            }
+            setLoading(false);
+        }
+
+        loadMembers().catch(() => {
+            setErrors({ form: 'Could not load group members.' });
+            setLoading(false);
+        });
+    }, [id]);
+
+    async function handleSubmit(event) {
+        event.preventDefault();
+
+        const found = validate({ amount, description, paidByUserId, expenseDate });
+        if (Object.keys(found).length > 0) {
+            setErrors(found);
+            return;
+        }
+
+        setSubmitting(true);
+        setErrors({});
+
+        try {
+            const result = await createExpense(id, {
+                amount,
+                description,
+                paidByUserId: Number(paidByUserId),
+                expenseDate
+            });
+
+            if (result.errors) {
+                setErrors(result.errors);
+                return;
+            }
+
+            navigate(`/groups/${id}`);          // AC7: back to the list the expense now appears in
+        } catch {
+            setErrors({ form: 'Could not add this expense. Please try again.' });
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    if (loading) {
+        return <div className="page"><p>Loading…</p></div>;
+    }
+
+    return (
+        <div className="page">
+            <div className="card">
+                <h1>Add an expense</h1>
+                <p className="subtitle">Split equally among everyone in the group</p>
+
+                <form onSubmit={handleSubmit} noValidate>
+                    <div className="form-group">
+                        <label htmlFor="amount">Amount</label>
+                        <input
+                            id="amount"
+                            type="number"
+                            step="0.01"
+                            value={amount}
+                            placeholder="0.00"
+                            onChange={(event) => setAmount(event.target.value)}
+                        />
+                        {errors.amount && <span className="error">{errors.amount}</span>}
+                    </div>
+
+                    <div className="form-group">
+                        <label htmlFor="description">Description</label>
+                        <input
+                            id="description"
+                            type="text"
+                            value={description}
+                            placeholder="What was it for?"
+                            onChange={(event) => setDescription(event.target.value)}
+                        />
+                        {errors.description && <span className="error">{errors.description}</span>}
+                    </div>
+
+                    <div className="form-group">
+                        <label htmlFor="paidByUserId">Paid by</label>
+                        <select
+                            id="paidByUserId"
+                            value={paidByUserId}
+                            onChange={(event) => setPaidByUserId(event.target.value)}
+                        >
+                            {/* AC5: only current members of the group */}
+                            {members.map((member) => (
+                                <option key={member.userId} value={member.userId}>
+                                    {member.username}
+                                </option>
+                            ))}
+                        </select>
+                        {errors.paidByUserId && <span className="error">{errors.paidByUserId}</span>}
+                    </div>
+
+                    <div className="form-group">
+                        <label htmlFor="expenseDate">Date</label>
+                        <input
+                            id="expenseDate"
+                            type="date"
+                            value={expenseDate}
+                            max={today()}                 // AC6: past dates only
+                            onChange={(event) => setExpenseDate(event.target.value)}
+                        />
+                        {errors.expenseDate && <span className="error">{errors.expenseDate}</span>}
+                    </div>
+
+                    {errors.form && <span className="error">{errors.form}</span>}
+
+                    <button type="submit" disabled={submitting}>
+                        {submitting ? 'Saving…' : 'Save expense'}
+                    </button>
+                </form>
+
+                <Link to={`/groups/${id}`}>Back to the group</Link>
+            </div>
+        </div>
+    );
+}
+
+export default AddExpense;

--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -8,3 +8,41 @@
 .balance {
     color: #333;
 }
+.expense-list,
+.balance-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.expense-list li {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 2px 12px;
+    padding: 10px 0;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.expense-description {
+    font-weight: 600;
+}
+
+.expense-amount {
+    grid-row: 1 / span 2;
+    grid-column: 2;
+    align-self: center;
+}
+
+.expense-meta {
+    font-size: 13px;
+    color: #666;
+}
+
+.balance-list li {
+    padding: 6px 0;
+}
+
+.action {
+    display: inline-block;
+    margin-bottom: 10px;
+}

--- a/frontend/src/pages/GroupPage.jsx
+++ b/frontend/src/pages/GroupPage.jsx
@@ -1,12 +1,30 @@
 import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { getGroup } from '../api/groups';
+import { getGroup, getGroupMembers } from '../api/groups';
+import { getExpenses } from '../api/expenses';
 import SettlementView from './SettlementView';
 import './GroupPage.css';
+
+function money(currency, value) {
+    return `${currency} ${Number(value).toFixed(2)}`;
+}
+
+function balanceLine(member, currency) {
+    const balance = Number(member.netBalance);
+    if (balance > 0) {
+        return `${member.username} is owed ${money(currency, balance)}`;
+    }
+    if (balance < 0) {
+        return `${member.username} owes ${money(currency, -balance)}`;
+    }
+    return `${member.username} is settled up`;
+}
 
 function GroupPage() {
     const { id } = useParams();
     const [group, setGroup] = useState(null);
+    const [expenses, setExpenses] = useState([]);
+    const [members, setMembers] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [notFound, setNotFound] = useState(false);
@@ -17,9 +35,21 @@ function GroupPage() {
                 const result = await getGroup(id);
                 if (result === null) {
                     setNotFound(true);        // AC8: not a member, or no such group
-                } else {
-                    setGroup(result);
+                    return;
                 }
+                setGroup(result);
+
+                const [expenseResult, memberResult] = await Promise.all([
+                    getExpenses(id),
+                    getGroupMembers(id),
+                ]);
+
+                if (expenseResult.error || memberResult.error) {
+                    setError(expenseResult.error || memberResult.error);
+                    return;
+                }
+                setExpenses(expenseResult.expenses);   // AC7
+                setMembers(memberResult.members);      // AC1
             } catch (err) {
                 console.error('Failed to load group', err);
                 setError('Could not load this group. Please try again.');
@@ -57,26 +87,54 @@ function GroupPage() {
         );
     }
 
+    const settled = members.every((member) => Number(member.netBalance) === 0);
+
     return (
         <div className="page">
-            <div className="card">
+            <div className="card group-card">
                 <h1>{group.name}</h1>
                 {group.description && <p className="subtitle">{group.description}</p>}
 
-                <Link to={`/groups/${id}/members`}>Manage members</Link>
-
                 <section>
                     <h2>Expenses</h2>
-                    {/* AC2: a new group has no expenses */}
-                    <p className="empty">No expenses yet.</p>
+                    <Link className="action" to={`/groups/${id}/expenses/new`}>Add an expense</Link>
+
+                    {/* AC7: every member sees the expense with amount, description, payer and date */}
+                    {expenses.length === 0 ? (
+                        <p className="empty">No expenses yet.</p>
+                    ) : (
+                        <ul className="expense-list">
+                            {expenses.map((expense) => (
+                                <li key={expense.id}>
+                                    <span className="expense-description">{expense.description}</span>
+                                    <span className="expense-meta">
+                                        {expense.paidByUsername} paid on {expense.expenseDate}
+                                    </span>
+                                    <span className="expense-amount">
+                                        {money(group.baseCurrency, expense.amount)}
+                                    </span>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
                 </section>
 
                 <section>
                     <h2>Balances</h2>
-                    {/* AC2: all balances are zero until expenses are added */}
-                    <p className="balance">
-                        Everyone is settled up. Balance: {group.baseCurrency} 0.00
-                    </p>
+                    {/* AC1: each member's balance reflects the expenses recorded so far */}
+                    {settled ? (
+                        <p className="balance">
+                            Everyone is settled up. Balance: {money(group.baseCurrency, 0)}
+                        </p>
+                    ) : (
+                        <ul className="balance-list">
+                            {members.map((member) => (
+                                <li key={member.userId} className="balance">
+                                    {balanceLine(member, group.baseCurrency)}
+                                </li>
+                            ))}
+                        </ul>
+                    )}
                 </section>
 
                 <section>

--- a/frontend/test/AddExpense.test.jsx
+++ b/frontend/test/AddExpense.test.jsx
@@ -1,0 +1,115 @@
+import { it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import AddExpense from '../src/pages/AddExpense.jsx';
+import { getGroupMembers } from '../src/api/groups';
+import { createExpense } from '../src/api/expenses';
+
+vi.mock('../src/api/groups', () => ({
+    getGroupMembers: vi.fn(),
+}));
+
+vi.mock('../src/api/expenses', () => ({
+    createExpense: vi.fn(),
+}));
+
+const MEMBERS = [
+    { userId: 1, username: 'alice', email: 'alice@test.com', netBalance: '0.00', currentUser: true },
+    { userId: 2, username: 'bob', email: 'bob@test.com', netBalance: '0.00', currentUser: false },
+];
+
+function today() {
+    return new Date().toISOString().slice(0, 10);
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    getGroupMembers.mockResolvedValue({ members: MEMBERS });
+    createExpense.mockResolvedValue({ expense: { id: 9 } });
+});
+
+function renderPage() {
+    render(
+        <MemoryRouter initialEntries={['/groups/1/expenses/new']}>
+            <Routes>
+                <Route path="/groups/:id/expenses/new" element={<AddExpense />} />
+                <Route path="/groups/:id" element={<h1>Flat 3</h1>} />
+            </Routes>
+        </MemoryRouter>
+    );
+}
+
+it('AC1: saves the expense and returns to the group', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(await screen.findByLabelText('Amount'), '42.50');
+    await user.type(screen.getByLabelText('Description'), 'Groceries');
+    await user.selectOptions(screen.getByLabelText('Paid by'), '2');
+    await user.click(screen.getByRole('button', { name: 'Save expense' }));
+
+    // The number input normalises 42.50 to 42.5; the backend stores it at two decimal places.
+    expect(createExpense).toHaveBeenCalledWith('1', {
+        amount: '42.5',
+        description: 'Groceries',
+        paidByUserId: 2,
+        expenseDate: today(),
+    });
+    expect(await screen.findByText('Flat 3')).toBeInTheDocument();
+});
+
+it('AC2: shows an inline error on each missing field', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole('button', { name: 'Save expense' }));
+
+    expect(screen.getByText('Amount is required')).toBeInTheDocument();
+    expect(screen.getByText('Description is required')).toBeInTheDocument();
+    expect(createExpense).not.toHaveBeenCalled();
+});
+
+it('AC3: rejects a zero, negative or non-numeric amount', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const amount = await screen.findByLabelText('Amount');
+    await user.type(screen.getByLabelText('Description'), 'Groceries');
+
+    for (const value of ['0', '-5']) {
+        await user.clear(amount);
+        await user.type(amount, value);
+        await user.click(screen.getByRole('button', { name: 'Save expense' }));
+
+        expect(screen.getByText('Amount must be a positive number')).toBeInTheDocument();
+    }
+    expect(createExpense).not.toHaveBeenCalled();
+});
+
+it('AC5: only current group members are selectable as payer', async () => {
+    renderPage();
+
+    const payer = await screen.findByLabelText('Paid by');
+
+    expect([...payer.options].map((option) => option.textContent)).toEqual(['alice', 'bob']);
+    expect(payer).toHaveValue('1');   // the current user is preselected
+});
+
+it('AC6: the date defaults to today and cannot be set in the future', async () => {
+    renderPage();
+
+    const date = await screen.findByLabelText('Date');
+
+    expect(date).toHaveValue(today());
+    expect(date).toHaveAttribute('max', today());
+});
+
+it('AC8: shows the error when the group is not readable', async () => {
+    getGroupMembers.mockResolvedValue({ error: 'You must be a group member to manage its members' });
+
+    renderPage();
+
+    expect(await screen.findByText('You must be a group member to manage its members'))
+        .toBeInTheDocument();
+});

--- a/frontend/test/AddExpense.test.jsx
+++ b/frontend/test/AddExpense.test.jsx
@@ -136,3 +136,15 @@ it('AC8: shows the error when the group is not readable', async () => {
     expect(await screen.findByText('You must be a group member to manage its members'))
         .toBeInTheDocument();
 });
+
+it('AC5: shows the error when the payer is no longer a group member', async () => {
+    createExpense.mockResolvedValue({ errors: { form: 'Payer must be a member of the group' } });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(await screen.findByLabelText('Amount'), '10');
+    await user.type(screen.getByLabelText('Description'), 'Taxi');
+    await user.click(screen.getByRole('button', { name: 'Save expense' }));
+
+    expect(await screen.findByText('Payer must be a member of the group')).toBeInTheDocument();
+});

--- a/frontend/test/AddExpense.test.jsx
+++ b/frontend/test/AddExpense.test.jsx
@@ -20,7 +20,10 @@ const MEMBERS = [
 ];
 
 function today() {
-    return new Date().toISOString().slice(0, 10);
+    const now = new Date();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    return `${now.getFullYear()}-${month}-${day}`;
 }
 
 beforeEach(() => {
@@ -103,6 +106,26 @@ it('AC6: the date defaults to today and cannot be set in the future', async () =
 
     expect(date).toHaveValue(today());
     expect(date).toHaveAttribute('max', today());
+});
+
+it('AC6: the date defaults to the local date, not the UTC one', async () => {
+    const originalTimeZone = process.env.TZ;
+    process.env.TZ = 'Pacific/Auckland';
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    // 01:00 on 21 August in Auckland is still 20 August in UTC.
+    vi.setSystemTime(new Date('2026-08-20T13:00:00Z'));
+
+    try {
+        renderPage();
+
+        const date = await screen.findByLabelText('Date');
+
+        expect(date).toHaveValue('2026-08-21');
+        expect(date).toHaveAttribute('max', '2026-08-21');
+    } finally {
+        vi.useRealTimers();
+        process.env.TZ = originalTimeZone;
+    }
 });
 
 it('AC8: shows the error when the group is not readable', async () => {

--- a/frontend/test/GroupPage.test.jsx
+++ b/frontend/test/GroupPage.test.jsx
@@ -2,16 +2,41 @@ import { it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import GroupPage from '../src/pages/GroupPage.jsx';
-import { getGroup } from '../src/api/groups';
+import { getGroup, getGroupBalances, getGroupMembers } from '../src/api/groups';
+import { getExpenses } from '../src/api/expenses';
 
 vi.mock('../src/api/groups', () => ({
     createGroup: vi.fn(),
     getGroups: vi.fn(),
     getGroup: vi.fn(),
+    getGroupMembers: vi.fn(),
+    getGroupBalances: vi.fn(),
+    computeSettlement: vi.fn(),
 }));
+
+vi.mock('../src/api/expenses', () => ({
+    getExpenses: vi.fn(),
+}));
+
+const GROUP = {
+    id: 1,
+    name: 'Flat 3',
+    description: null,
+    baseCurrency: 'NZD',
+    createdAt: '2026-08-16T00:00:00Z',
+    memberCount: 2,
+};
 
 beforeEach(() => {
     vi.clearAllMocks();
+    getGroup.mockResolvedValue(GROUP);
+    getExpenses.mockResolvedValue({ expenses: [] });
+    getGroupBalances.mockResolvedValue([]);
+    getGroupMembers.mockResolvedValue({
+        members: [
+            { userId: 1, username: 'alice', email: 'alice@test.com', netBalance: '0.00', currentUser: true },
+        ],
+    });
 });
 
 function renderPage() {
@@ -25,20 +50,51 @@ function renderPage() {
 }
 
 it('AC2: a new group lists no expenses and shows zero balances', async () => {
-    getGroup.mockResolvedValue({
-        id: 1,
-        name: 'Flat 3',
-        description: null,
-        baseCurrency: 'NZD',
-        createdAt: '2026-08-16T00:00:00Z',
-        memberCount: 1,
-    });
-
     renderPage();
 
     expect(await screen.findByText('Flat 3')).toBeInTheDocument();
     expect(screen.getByText('No expenses yet.')).toBeInTheDocument();
     expect(screen.getByText(/NZD 0\.00/)).toBeInTheDocument();
+});
+
+it('AC7: lists each expense with amount, description, payer and date', async () => {
+    getExpenses.mockResolvedValue({
+        expenses: [
+            {
+                id: 2, groupId: 1, paidByUserId: 2, paidByUsername: 'bob',
+                amount: '20.00', description: 'Pizza', expenseDate: '2026-08-18',
+                createdAt: '2026-08-18T00:00:00Z',
+            },
+            {
+                id: 1, groupId: 1, paidByUserId: 1, paidByUsername: 'alice',
+                amount: '10.00', description: 'Taxi', expenseDate: '2026-08-16',
+                createdAt: '2026-08-16T00:00:00Z',
+            },
+        ],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Pizza')).toBeInTheDocument();
+    expect(screen.getByText('bob paid on 2026-08-18')).toBeInTheDocument();
+    expect(screen.getByText('NZD 20.00')).toBeInTheDocument();
+    expect(screen.getByText('Taxi')).toBeInTheDocument();
+    expect(screen.getByText('alice paid on 2026-08-16')).toBeInTheDocument();
+    expect(screen.getByText('NZD 10.00')).toBeInTheDocument();
+});
+
+it('AC1: shows what each member is owed or owes', async () => {
+    getGroupMembers.mockResolvedValue({
+        members: [
+            { userId: 1, username: 'alice', email: 'alice@test.com', netBalance: '-21.25', currentUser: true },
+            { userId: 2, username: 'bob', email: 'bob@test.com', netBalance: '21.25', currentUser: false },
+        ],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('alice owes NZD 21.25')).toBeInTheDocument();
+    expect(screen.getByText('bob is owed NZD 21.25')).toBeInTheDocument();
 });
 
 it('AC8: shows a not-found message when the user is not a member', async () => {

--- a/frontend/test/expensesApi.test.js
+++ b/frontend/test/expensesApi.test.js
@@ -1,0 +1,32 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { createExpense } from '../src/api/expenses';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+function respondWith(status, body) {
+    const fetchMock = vi.fn().mockResolvedValue({
+        ok: status < 400,
+        status,
+        json: () => Promise.resolve(body)
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+}
+
+it('keeps field messages under the field they belong to', async () => {
+    respondWith(400, { amount: 'Amount must be at least 0.01' });
+
+    const result = await createExpense(1, { amount: '0.004' });
+
+    expect(result.errors).toEqual({ amount: 'Amount must be at least 0.01' });
+});
+
+it('moves a message that belongs to no field onto the form', async () => {
+    respondWith(400, { error: 'Payer must be a member of the group' });
+
+    const result = await createExpense(1, { paidByUserId: 7 });
+
+    expect(result.errors).toEqual({ form: 'Payer must be a member of the group' });
+});


### PR DESCRIPTION
## Summary
Adds the write path for expenses. A group member can record an amount, description, payer and date, and the expense is split equally across the group so every member's balance reflects it.

## Associated issue
Closes #6

## Changes

- `POST /groups/{id}/expenses` and `GET /groups/{id}/expenses`, both restricted to members of the group
- Each new expense is split equally across the group's current members and applied to the `net_balance` field #47 added, as agreed in the coordination comment on #4
- Cents left over by an uneven division go to the lowest user ids, so the shares always sum to the amount
- `V4__create_expenses_table.sql`, since #47 holds V3
- An "Add an expense" form at `/groups/:id/expenses/new` with the payer drawn from the group's members, a date defaulting to today that rejects future dates, and an error on each invalid field
- The group page now lists the group's expenses and each member's balance

## Testing
`./mvnw test` in `backend`: 37 tests pass (11 new) in `ExpenseIntegrationTest` covering AC1 through AC8.
`npm test` in `frontend`: 34 tests pass, 8 in `AddExpense.test.jsx` and 2 in the new `expensesApi.test.js`, with `GroupPage.test.jsx` extended for the expense list and the balances.

Checked manually against a running backend and dev server, as user `miro` in a two-member group: an empty form shows an error per field, a zero or negative amount is refused, the payer dropdown holds only the group's members, a future date is refused and a past one accepted, and a 5.50 expense paid by the other member left balances of -2.75 and +2.75 that sum to zero.

AC7's second-member view and AC8's non-member rejection cannot be reached through the UI while `StubCurrentUserProvider` signs every request in as the first user, so both are covered by `ExpenseIntegrationTest` only.

## Dependencies
Depended on #4, merged as #47, and this branch is rebased onto it. Blocks #8, which takes over the split logic for split methods and subsets. No new dependency in `backend/pom.xml` or `frontend/package.json`.

## Reviewer notes
The expense endpoints throw `GroupAccessDeniedException` (403) for a non-member, matching the convention #4 set for the member endpoints rather than the 404 `getGroup` still returns.

`readError` and `requirePositiveInteger` are now exported from `frontend/src/api/groups.js` so `expenses.js` can use them instead of holding a copy.

The split writes straight to `net_balance` with no per-expense share rows. #8 can add them if it needs them.

## Generative AI
Not applicable.