### PR TITLE
Restore Manage members link on group page

### DIFF
--- a/frontend/src/pages/GroupPage.jsx
+++ b/frontend/src/pages/GroupPage.jsx
@@ -95,6 +95,8 @@ function GroupPage() {
                 <h1>{group.name}</h1>
                 {group.description && <p className="subtitle">{group.description}</p>}
 
+                <Link to={`/groups/${id}/members`}>Manage members</Link>
+
                 <section>
                     <h2>Expenses</h2>
                     <Link className="action" to={`/groups/${id}/expenses/new`}>Add an expense</Link>

--- a/frontend/test/GroupPage.test.jsx
+++ b/frontend/test/GroupPage.test.jsx
@@ -57,6 +57,13 @@ it('AC2: a new group lists no expenses and shows zero balances', async () => {
     expect(screen.getByText(/NZD 0\.00/)).toBeInTheDocument();
 });
 
+it('links to member management from the group page', async () => {
+    renderPage();
+
+    const link = await screen.findByRole('link', { name: 'Manage members' });
+    expect(link).toHaveAttribute('href', '/groups/1/members');
+});
+
 it('AC7: lists each expense with amount, description, payer and date', async () => {
     getExpenses.mockResolvedValue({
         expenses: [


### PR DESCRIPTION
## Summary
Restores access to the existing member management page from each group page.

## Associated issue
Closes #51

## Changes
- Restored the `Manage members` link on the group page.
- Added a regression test for the link and its route.

## Testing
- `cd frontend && npm test` - 10 test files and 41 tests passed.
- `cd frontend && npm run build` - production build succeeded.
- `cd backend && .\mvnw.cmd --batch-mode clean verify` - 44 tests passed with no failures, errors or skipped tests.
- Ran the application against MySQL 8.4, created a group, and confirmed `Manage members` opens `/groups/1/members`.

## Dependencies
None. No new external dependencies were added.

## Screenshots
Not included. This restores a single navigation link, which was checked in the running application.

## Reviewer notes
Please check that `Manage members` is visible on the group page and opens the existing member management page.

## Generative AI
Minimal help used to implement and verify this fix. All changes manually reviewed.

## Checklist
- [x] Associated with an open, team-approved issue
- [x] Branched from `main` and rebased against it
- [x] Test suite passes and the application runs
- [x] Tests are added alongside any new or modified code
- [x] No unrelated changes are included
- [x] Documentation updated where the change requires it
- [x] Any use of generative AI is acknowledged above
