### PR TITLE
Feat/8 split expenses

### DIFF
--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/controller/ExpenseController.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/controller/ExpenseController.java
@@ -32,8 +32,24 @@ public class ExpenseController {
                 .body(created);
     }
 
+    @PutMapping("/{expenseId}")
+    public ResponseEntity<Void> update(@PathVariable Long groupId,
+                                       @PathVariable Long expenseId,
+                                       @Valid @RequestBody CreateExpenseRequest request) {
+        expenseService.updateExpense(groupId, request, currentUser.currentUserId(), expenseId);
+        return ResponseEntity.noContent().build();
+    }
+
     @GetMapping
     public List<ExpenseResponse> list(@PathVariable Long groupId) {
         return expenseService.getExpensesForGroup(groupId, currentUser.currentUserId());
+    }
+
+    @GetMapping("/{expenseId}")
+    public ResponseEntity<ExpenseResponse> get(
+            @PathVariable Long groupId,
+            @PathVariable Long expenseId) {
+        return ResponseEntity.ok(
+                expenseService.getExpense(groupId, expenseId, currentUser.currentUserId()));
     }
 }

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/dto/CreateExpenseRequest.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/dto/CreateExpenseRequest.java
@@ -6,7 +6,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
-
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
@@ -23,6 +24,9 @@ public record CreateExpenseRequest(
 
         @NotNull(message = "Payer is required")
         Long paidByUserId,
+
+        @NotEmpty(message = "At least one participant is required")
+        List<Long> participantUserIds,
 
         @PastOrPresent(message = "Expense date cannot be in the future")
         LocalDate expenseDate) {}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/dto/ExpenseResponse.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/dto/ExpenseResponse.java
@@ -3,7 +3,9 @@ package nz.ac.auckland.se310.fairshare.dto;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.List;
 
 public record ExpenseResponse(
         Long id, Long groupId, Long paidByUserId, String paidByUsername,
-        BigDecimal amount, String description, LocalDate expenseDate, Instant createdAt) {}
+        BigDecimal amount, String description, LocalDate expenseDate, Instant createdAt,
+        List<Long> participantUserIds) {}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/exception/ExpenseNotFoundException.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/exception/ExpenseNotFoundException.java
@@ -1,0 +1,8 @@
+package nz.ac.auckland.se310.fairshare.exception;
+
+public class ExpenseNotFoundException extends RuntimeException {
+
+    public ExpenseNotFoundException() {
+        super("Expense not found in group");
+    }
+}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/model/Expense.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/model/Expense.java
@@ -55,6 +55,7 @@ public class Expense {
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }
     public LocalDate getExpenseDate() { return expenseDate; }
+    public void setExpenseDate(LocalDate expenseDate) { this.expenseDate = expenseDate; }
     public Instant getCreatedAt() { return createdAt; }
 
     @Override

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/model/Expense.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/model/Expense.java
@@ -20,7 +20,7 @@ public class Expense {
     private ExpenseGroup group;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "paid_by", nullable = false, updatable = false)
+    @JoinColumn(name = "paid_by", nullable = false)
     private User paidBy;
 
     @Column(name = "amount", nullable = false, precision = 10, scale = 2)
@@ -49,8 +49,11 @@ public class Expense {
     public Long getId() { return id; }
     public ExpenseGroup getGroup() { return group; }
     public User getPaidBy() { return paidBy; }
+    public void setPaidBy(User paidBy) { this.paidBy = paidBy; }
     public BigDecimal getAmount() { return amount; }
+    public void setAmount(BigDecimal amount) { this.amount = amount; }
     public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
     public LocalDate getExpenseDate() { return expenseDate; }
     public Instant getCreatedAt() { return createdAt; }
 

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/model/ExpenseShare.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/model/ExpenseShare.java
@@ -1,0 +1,54 @@
+package nz.ac.auckland.se310.fairshare.model;
+
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table (
+        name = "expense_share",
+        uniqueConstraints = 
+        @UniqueConstraint(name = "uq_es_user_expense", columnNames = {"user_id", "expense_id"}))
+public class ExpenseShare {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "expense_share_id")
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "expense_id", nullable = false)
+    private Expense expense;
+
+    @Column(name = "share_amount", nullable = false, precision = 19, scale = 2)
+    private BigDecimal shareAmount = BigDecimal.ZERO.setScale(2);
+
+    protected ExpenseShare() {} // JPA
+
+    public ExpenseShare(User user, Expense expense, BigDecimal shareAmount) {
+        this.user = user;
+        this.expense = expense;
+        this.shareAmount = shareAmount.setScale(2);
+    }
+
+    public long getId() { return id; }
+    public User getUser() { return user; }
+    public Expense getExpense() { return expense; }
+    public BigDecimal getShareAmount() { return shareAmount; }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof ExpenseShare other)) return false;
+        return id != 0 && id == other.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/repository/ExpenseRepository.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/repository/ExpenseRepository.java
@@ -2,6 +2,7 @@ package nz.ac.auckland.se310.fairshare.repository;
 
 import nz.ac.auckland.se310.fairshare.model.Expense;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 import java.util.List;
 
@@ -9,4 +10,6 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
     // AC7: newest first for the group's expense list
     List<Expense> findByGroupIdOrderByExpenseDateDesc(Long groupId);
+
+    Optional<Expense> findByIdAndGroupId(Long expenseId, Long groupId);
 }

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/repository/ExpenseShareRepository.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/repository/ExpenseShareRepository.java
@@ -1,0 +1,9 @@
+package nz.ac.auckland.se310.fairshare.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import nz.ac.auckland.se310.fairshare.model.ExpenseShare;
+import java.util.List;
+
+public interface ExpenseShareRepository extends JpaRepository<ExpenseShare, Long> {
+    List<ExpenseShare> findByExpenseId(Long expenseId);
+}

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/service/ExpenseService.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/service/ExpenseService.java
@@ -48,6 +48,7 @@ public class ExpenseService {
         }
 
         List<UserInGroup> members = request.participantUserIds().stream()
+                .distinct() // duplicate IDs must not be counted more than once in the split
                 .map(group::getMember)
                 .filter(java.util.Objects::nonNull)
                 .sorted(Comparator.comparingLong(m -> m.getUser().getId()))
@@ -83,6 +84,7 @@ public class ExpenseService {
         }
 
         List<UserInGroup> members = request.participantUserIds().stream()
+                .distinct() // duplicate IDs must not be counted more than once in the split
                 .map(group::getMember)
                 .filter(java.util.Objects::nonNull)
                 .sorted(Comparator.comparingLong(m -> m.getUser().getId()))
@@ -161,6 +163,9 @@ public class ExpenseService {
             }
             expenseShareRepository.delete(share);
         }
+        // Flush so the deletes hit the DB before the new shares are inserted, otherwise the
+        // unique constraint on (user_id, expense_id) can be violated by Hibernate's action ordering.
+        expenseShareRepository.flush();
         originalPayer.adjustNetBalance(expense.getAmount().negate());
 
         // Apply the new split

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/service/ExpenseService.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/service/ExpenseService.java
@@ -3,11 +3,14 @@ package nz.ac.auckland.se310.fairshare.service;
 import nz.ac.auckland.se310.fairshare.dto.CreateExpenseRequest;
 import nz.ac.auckland.se310.fairshare.dto.ExpenseResponse;
 import nz.ac.auckland.se310.fairshare.exception.GroupAccessDeniedException;
+import nz.ac.auckland.se310.fairshare.exception.ExpenseNotFoundException;
 import nz.ac.auckland.se310.fairshare.exception.InvalidPayerException;
 import nz.ac.auckland.se310.fairshare.model.Expense;
 import nz.ac.auckland.se310.fairshare.model.ExpenseGroup;
+import nz.ac.auckland.se310.fairshare.model.ExpenseShare;
 import nz.ac.auckland.se310.fairshare.model.UserInGroup;
 import nz.ac.auckland.se310.fairshare.repository.ExpenseRepository;
+import nz.ac.auckland.se310.fairshare.repository.ExpenseShareRepository;
 import nz.ac.auckland.se310.fairshare.repository.ExpenseGroupRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,10 +28,13 @@ public class ExpenseService {
 
     private final ExpenseRepository expenseRepository;
     private final ExpenseGroupRepository groupRepository;
+    private final ExpenseShareRepository expenseShareRepository;
 
-    public ExpenseService(ExpenseRepository expenseRepository, ExpenseGroupRepository groupRepository) {
+
+    public ExpenseService(ExpenseRepository expenseRepository, ExpenseGroupRepository groupRepository, ExpenseShareRepository expenseShareRepository) {
         this.expenseRepository = expenseRepository;
         this.groupRepository = groupRepository;
+        this.expenseShareRepository = expenseShareRepository;
     }
 
     @Transactional
@@ -41,6 +47,15 @@ public class ExpenseService {
             throw new InvalidPayerException(request.paidByUserId()); // AC5
         }
 
+        List<UserInGroup> members = request.participantUserIds().stream()
+                .map(group::getMember)
+                .filter(java.util.Objects::nonNull)
+                .sorted(Comparator.comparingLong(m -> m.getUser().getId()))
+                .toList();
+        if (members.isEmpty()) {
+            throw new IllegalStateException("No valid participants found in the group for the expense");
+        }
+
         BigDecimal amount = request.amount().setScale(MONEY_SCALE, RoundingMode.HALF_UP);
         LocalDate expenseDate = request.expenseDate() != null ? request.expenseDate() : LocalDate.now(); // AC6
 
@@ -48,9 +63,43 @@ public class ExpenseService {
                 group, payer.getUser(), amount, request.description().trim(), expenseDate);
         Expense saved = expenseRepository.save(expense);
 
-        applyEqualSplit(group, payer, amount); // AC1, AC4
+        applyEqualSplit(payer, amount, members, saved); // AC1, AC4
 
         return toResponse(saved);
+    }
+
+    @Transactional
+    public void updateExpense(Long groupId, CreateExpenseRequest request, Long currentUserId, Long expenseId) {
+        ExpenseGroup group = groupRepository.findByIdAndMembersUserId(groupId, currentUserId)
+                .orElseThrow(GroupAccessDeniedException::new); // AC8
+
+        Expense expense = expenseRepository.findByIdAndGroupId(expenseId, groupId)
+                .orElseThrow(ExpenseNotFoundException::new);
+
+        UserInGroup originalPayer = group.getMember(expense.getPaidBy().getId());
+        UserInGroup payer = group.getMember(request.paidByUserId());
+        if (payer == null) {
+            throw new InvalidPayerException(request.paidByUserId());
+        }
+
+        List<UserInGroup> members = request.participantUserIds().stream()
+                .map(group::getMember)
+                .filter(java.util.Objects::nonNull)
+                .sorted(Comparator.comparingLong(m -> m.getUser().getId()))
+                .toList();
+        if (members.isEmpty()) {
+            throw new IllegalStateException("No valid participants found in the group for the expense");
+        }
+
+        BigDecimal amount = request.amount().setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+
+        updateSplit(expense, originalPayer, payer, amount, members);
+
+        expense.setAmount(amount);
+        expense.setDescription(request.description().trim());
+        expense.setPaidBy(payer.getUser());
+
+        expenseRepository.save(expense);
     }
 
     @Transactional(readOnly = true)
@@ -64,16 +113,23 @@ public class ExpenseService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public ExpenseResponse getExpense(Long groupId, Long expenseId, Long currentUserId) {
+        groupRepository.findByIdAndMembersUserId(groupId, currentUserId)
+                .orElseThrow(GroupAccessDeniedException::new);
+
+        Expense expense = expenseRepository.findByIdAndGroupId(expenseId, groupId)
+                .orElseThrow(() -> new IllegalArgumentException("Expense not found in group"));
+
+        return toResponse(expense);
+    }
+
     /**
      * AC4: the amount is split equally across every current member. Cents left over by an
      * uneven division go to the lowest user ids, so the shares always add back up to the
      * amount the payer actually spent.
      */
-    private void applyEqualSplit(ExpenseGroup group, UserInGroup payer, BigDecimal amount) {
-        List<UserInGroup> members = group.getMembers().stream()
-                .sorted(Comparator.comparing(member -> member.getUser().getId()))
-                .toList();
-
+    private void applyEqualSplit(UserInGroup payer, BigDecimal amount, List<UserInGroup> members, Expense expense) {
         long totalCents = amount.movePointRight(MONEY_SCALE).longValueExact();
         long baseShare = totalCents / members.size();
         long extraCents = totalCents % members.size();
@@ -83,7 +139,29 @@ public class ExpenseService {
         for (int i = 0; i < members.size(); i++) {
             long shareCents = baseShare + (i < extraCents ? 1 : 0);
             members.get(i).adjustNetBalance(cents(-shareCents));
+            try {
+                expenseShareRepository.save(new ExpenseShare(members.get(i).getUser(), expense, cents(shareCents)));
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to save expense share for user " + members.get(i).getUser().getId(), e);
+            }
         }
+    }
+
+    private void updateSplit(Expense expense, UserInGroup originalPayer, UserInGroup newPayer,
+                             BigDecimal newAmount, List<UserInGroup> members) {
+        // First, reverse the previous split
+        List<ExpenseShare> existingShares = expenseShareRepository.findByExpenseId(expense.getId());
+        for (ExpenseShare share : existingShares) {
+            UserInGroup member = expense.getGroup().getMember(share.getUser().getId());
+            if (member != null) {
+                member.adjustNetBalance(share.getShareAmount());
+            }
+            expenseShareRepository.delete(share);
+        }
+        originalPayer.adjustNetBalance(expense.getAmount().negate());
+
+        // Apply the new split
+        applyEqualSplit(newPayer, newAmount, members, expense);
     }
 
     private BigDecimal cents(long value) {

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/service/ExpenseService.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/service/ExpenseService.java
@@ -180,6 +180,10 @@ public class ExpenseService {
                 expense.getAmount(),
                 expense.getDescription(),
                 expense.getExpenseDate(),
-                expense.getCreatedAt());
+                expense.getCreatedAt(),
+                expenseShareRepository.findByExpenseId(expense.getId()).stream()
+                    .map(share -> share.getUser().getId())
+                    .sorted()
+                    .toList());
     }
 }

--- a/backend/src/main/java/nz/ac/auckland/se310/fairshare/service/ExpenseService.java
+++ b/backend/src/main/java/nz/ac/auckland/se310/fairshare/service/ExpenseService.java
@@ -98,6 +98,9 @@ public class ExpenseService {
         expense.setAmount(amount);
         expense.setDescription(request.description().trim());
         expense.setPaidBy(payer.getUser());
+        if (request.expenseDate() != null) {
+            expense.setExpenseDate(request.expenseDate());
+        }
 
         expenseRepository.save(expense);
     }

--- a/backend/src/main/resources/db/migration/V5__create_expense_share_table.sql
+++ b/backend/src/main/resources/db/migration/V5__create_expense_share_table.sql
@@ -6,5 +6,7 @@ CREATE TABLE expense_share (
     CONSTRAINT fk_expense_share_expense
         FOREIGN KEY (expense_id) REFERENCES expense (expense_id),
     CONSTRAINT fk_expense_share_user
-        FOREIGN KEY (user_id) REFERENCES users (id)
+        FOREIGN KEY (user_id) REFERENCES users (id),
+    CONSTRAINT uq_es_user_expense
+        UNIQUE (user_id, expense_id)
 );

--- a/backend/src/main/resources/db/migration/V5__create_expense_share_table.sql
+++ b/backend/src/main/resources/db/migration/V5__create_expense_share_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE expense_share (
+    expense_share_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    expense_id       BIGINT NOT NULL,
+    user_id          BIGINT NOT NULL,
+    share_amount     DECIMAL(10,2) NOT NULL,
+    CONSTRAINT fk_expense_share_expense
+        FOREIGN KEY (expense_id) REFERENCES expense (expense_id),
+    CONSTRAINT fk_expense_share_user
+        FOREIGN KEY (user_id) REFERENCES users (id)
+);

--- a/backend/src/test/java/nz/ac/auckland/se310/fairshare/ExpenseIntegrationTest.java
+++ b/backend/src/test/java/nz/ac/auckland/se310/fairshare/ExpenseIntegrationTest.java
@@ -165,6 +165,19 @@ class ExpenseIntegrationTest {
     }
 
     @Test
+    void ac4_duplicateParticipantIdsAreCountedOnce() {
+        var request = new CreateExpenseRequest(
+                new BigDecimal("20.00"), "Taxi", aliceId, List.of(aliceId, aliceId, bobId), null);
+
+        ExpenseResponse created = expenseService.createExpense(groupId, request, aliceId);
+
+        assertThat(created.participantUserIds()).containsExactlyInAnyOrder(aliceId, bobId);
+        assertThat(balances()).containsOnly(
+                Map.entry(aliceId, new BigDecimal("10.00")),
+                Map.entry(bobId, new BigDecimal("-10.00")));
+    }
+
+    @Test
     void ac5_payerMustBeAGroupMember() {
         var request = new CreateExpenseRequest(new BigDecimal(TAXI_AMOUNT), "Taxi", carolId, memberIds, null);
 

--- a/backend/src/test/java/nz/ac/auckland/se310/fairshare/ExpenseIntegrationTest.java
+++ b/backend/src/test/java/nz/ac/auckland/se310/fairshare/ExpenseIntegrationTest.java
@@ -257,6 +257,20 @@ class ExpenseIntegrationTest {
                 Map.entry(aliceId, new BigDecimal("-25.00")));
     }
 
+    @Test
+    void ac7_editingAnExpensePersistsTheNewExpenseDate() {
+        LocalDate originalDate = LocalDate.of(2026, Month.AUGUST, 1);
+        LocalDate updatedDate = LocalDate.of(2026, Month.AUGUST, 15);
+        ExpenseResponse created = expenseService.createExpense(groupId, new CreateExpenseRequest(
+                new BigDecimal(GROCERIES_AMOUNT), GROCERIES, bobId, memberIds, originalDate), aliceId);
+
+        expenseService.updateExpense(groupId, new CreateExpenseRequest(
+                new BigDecimal(GROCERIES_AMOUNT), GROCERIES, bobId, memberIds, updatedDate), aliceId, created.id());
+
+        assertThat(expenseService.getExpense(groupId, created.id(), aliceId).expenseDate())
+                .isEqualTo(updatedDate);
+    }
+
     @Test 
     void ac7_removingAParticipantFromAnExpenseUpdatesTheBalances() {
         groupService.addMember(groupId, CAROL_EMAIL, aliceId);

--- a/backend/src/test/java/nz/ac/auckland/se310/fairshare/ExpenseIntegrationTest.java
+++ b/backend/src/test/java/nz/ac/auckland/se310/fairshare/ExpenseIntegrationTest.java
@@ -97,6 +97,7 @@ class ExpenseIntegrationTest {
         assertThat(created.paidByUserId()).isEqualTo(bobId);
         assertThat(created.paidByUsername()).isEqualTo("bob");
         assertThat(created.expenseDate()).isEqualTo(LocalDate.of(2026, Month.AUGUST, 1));
+        assertThat(created.participantUserIds()).containsExactlyInAnyOrder(aliceId, bobId);
         assertThat(expenseRepository.findById(created.id())).isPresent();
     }
 

--- a/backend/src/test/java/nz/ac/auckland/se310/fairshare/ExpenseIntegrationTest.java
+++ b/backend/src/test/java/nz/ac/auckland/se310/fairshare/ExpenseIntegrationTest.java
@@ -11,6 +11,7 @@ import nz.ac.auckland.se310.fairshare.exception.InvalidPayerException;
 import nz.ac.auckland.se310.fairshare.model.User;
 import nz.ac.auckland.se310.fairshare.repository.ExpenseGroupRepository;
 import nz.ac.auckland.se310.fairshare.repository.ExpenseRepository;
+import nz.ac.auckland.se310.fairshare.repository.ExpenseShareRepository;
 import nz.ac.auckland.se310.fairshare.service.ExpenseGroupService;
 import nz.ac.auckland.se310.fairshare.service.ExpenseService;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,6 +55,7 @@ class ExpenseIntegrationTest {
     @Autowired ExpenseService expenseService;
     @Autowired ExpenseGroupRepository groupRepository;
     @Autowired ExpenseRepository expenseRepository;
+    @Autowired ExpenseShareRepository expenseShareRepository;
     @Autowired UserRepository userRepository;
     @Autowired Validator validator;
 
@@ -61,9 +63,11 @@ class ExpenseIntegrationTest {
     private Long bobId;
     private Long carolId;
     private Long groupId;
+    private List<Long> memberIds;
 
     @BeforeEach
     void setUp() {
+        expenseShareRepository.deleteAll();
         expenseRepository.deleteAll();
         groupRepository.deleteAll();
 
@@ -73,6 +77,7 @@ class ExpenseIntegrationTest {
                 .orElseGet(() -> userRepository.save(new User(
                         "carol", "x", CAROL_EMAIL, User.Country.NEW_ZEALAND, User.Currency.NZD)))
                 .getId();
+        memberIds = List.of(aliceId, bobId, carolId);
 
         groupId = groupService.createGroup(new CreateGroupRequest("Flat 3", null), aliceId).id();
         groupService.addMember(groupId, "bob@test.com", aliceId);
@@ -81,7 +86,7 @@ class ExpenseIntegrationTest {
     @Test
     void ac1_createsExpenseWithGivenDetails() {
         var request = new CreateExpenseRequest(
-                new BigDecimal(GROCERIES_AMOUNT), GROCERIES, bobId, LocalDate.of(2026, Month.AUGUST, 1));
+                new BigDecimal(GROCERIES_AMOUNT), GROCERIES, bobId, memberIds, LocalDate.of(2026, Month.AUGUST, 1));
 
         ExpenseResponse created = expenseService.createExpense(groupId, request, aliceId);
 
@@ -96,8 +101,8 @@ class ExpenseIntegrationTest {
     }
 
     @Test
-    void ac1_balancesReflectTheNewExpense() {
-        var request = new CreateExpenseRequest(new BigDecimal(GROCERIES_AMOUNT), GROCERIES, bobId, null);
+    void ac1_balancesReflectTheNewExpense() { // Also tests #8 AC4 & AC5
+        var request = new CreateExpenseRequest(new BigDecimal(GROCERIES_AMOUNT), GROCERIES, bobId, memberIds, null);
 
         expenseService.createExpense(groupId, request, aliceId);
 
@@ -108,30 +113,30 @@ class ExpenseIntegrationTest {
 
     @Test
     void ac2AndAc3_rejectsMissingFieldsAndNonPositiveAmounts() {
-        assertThat(violations(new CreateExpenseRequest(null, "  ", null, null)))
+        assertThat(violations(new CreateExpenseRequest(null, "  ", null, memberIds, null)))
                 .containsOnlyKeys(AMOUNT_FIELD, "description", "paidByUserId");
 
-        assertThat(violations(new CreateExpenseRequest(BigDecimal.ZERO, "Taxi", aliceId, null)))
+        assertThat(violations(new CreateExpenseRequest(BigDecimal.ZERO, "Taxi", aliceId, memberIds, null)))
                 .extractingByKey(AMOUNT_FIELD, list(String.class))
                 .contains("Amount must be a positive number");
 
-        assertThat(violations(new CreateExpenseRequest(new BigDecimal("-5.00"), "Taxi", aliceId, null)))
+        assertThat(violations(new CreateExpenseRequest(new BigDecimal("-5.00"), "Taxi", aliceId, memberIds, null)))
                 .extractingByKey(AMOUNT_FIELD, list(String.class))
                 .contains("Amount must be a positive number");
     }
 
     @Test
     void ac3_rejectsAmountsSmallerThanOneCent() {
-        assertThat(violations(new CreateExpenseRequest(new BigDecimal("0.004"), "Taxi", aliceId, null)))
+        assertThat(violations(new CreateExpenseRequest(new BigDecimal("0.004"), "Taxi", aliceId, memberIds, null)))
                 .extractingByKey(AMOUNT_FIELD, list(String.class))
                 .containsExactly("Amount must be at least 0.01");
     }
 
     @Test
-    void ac4_splitsEquallyAcrossAllCurrentMembers() {
+    void ac4_splitsEquallyAcrossAllCurrentMembers() { // Also tests #8 AC1
         groupService.addMember(groupId, CAROL_EMAIL, aliceId);
 
-        var request = new CreateExpenseRequest(new BigDecimal("90.00"), "Power bill", aliceId, null);
+        var request = new CreateExpenseRequest(new BigDecimal("90.00"), "Power bill", aliceId, memberIds, null);
 
         expenseService.createExpense(groupId, request, aliceId);
 
@@ -142,10 +147,10 @@ class ExpenseIntegrationTest {
     }
 
     @Test
-    void ac4_unevenSplitStillSumsToTheAmount() {
+    void ac4_unevenSplitStillSumsToTheAmount() { // Also tests #8 AC2
         groupService.addMember(groupId, CAROL_EMAIL, aliceId);
 
-        var request = new CreateExpenseRequest(new BigDecimal("100.00"), "Internet", aliceId, null);
+        var request = new CreateExpenseRequest(new BigDecimal("100.00"), "Internet", aliceId, memberIds, null);
 
         expenseService.createExpense(groupId, request, aliceId);
 
@@ -160,7 +165,7 @@ class ExpenseIntegrationTest {
 
     @Test
     void ac5_payerMustBeAGroupMember() {
-        var request = new CreateExpenseRequest(new BigDecimal(TAXI_AMOUNT), "Taxi", carolId, null);
+        var request = new CreateExpenseRequest(new BigDecimal(TAXI_AMOUNT), "Taxi", carolId, memberIds, null);
 
         assertThatThrownBy(() -> expenseService.createExpense(groupId, request, aliceId))
                 .isInstanceOf(InvalidPayerException.class);
@@ -168,7 +173,7 @@ class ExpenseIntegrationTest {
 
     @Test
     void ac6_expenseDateDefaultsToTodayWhenOmitted() {
-        var request = new CreateExpenseRequest(new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, null);
+        var request = new CreateExpenseRequest(new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, memberIds, null);
 
         ExpenseResponse created = expenseService.createExpense(groupId, request, aliceId);
 
@@ -178,21 +183,21 @@ class ExpenseIntegrationTest {
     @Test
     void ac6_rejectsAFutureDateAndAcceptsAPastOne() {
         assertThat(violations(new CreateExpenseRequest(
-                new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, LocalDate.now().plusDays(1))))
+                new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, memberIds, LocalDate.now().plusDays(1))))
                 .extractingByKey("expenseDate", list(String.class))
                 .containsExactly("Expense date cannot be in the future");
 
         assertThat(violations(new CreateExpenseRequest(
-                new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, LocalDate.now().minusDays(30))))
+                new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, memberIds, LocalDate.now().minusDays(30))))
                 .isEmpty();
     }
 
     @Test
     void ac7_listsGroupExpensesForEveryMemberNewestFirst() {
         expenseService.createExpense(groupId, new CreateExpenseRequest(
-                new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, LocalDate.now().minusDays(3)), aliceId);
+                new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, memberIds, LocalDate.now().minusDays(3)), aliceId);
         expenseService.createExpense(groupId, new CreateExpenseRequest(
-                new BigDecimal("20.00"), "Pizza", bobId, LocalDate.now().minusDays(1)), aliceId);
+                new BigDecimal("20.00"), "Pizza", bobId, memberIds, LocalDate.now().minusDays(1)), aliceId);
 
         List<ExpenseResponse> expenses = expenseService.getExpensesForGroup(groupId, bobId);
 
@@ -206,12 +211,65 @@ class ExpenseIntegrationTest {
 
     @Test
     void ac8_nonMemberCannotCreateOrViewExpenses() {
-        var request = new CreateExpenseRequest(new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, null);
+        var request = new CreateExpenseRequest(new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, memberIds, null);
 
         assertThatThrownBy(() -> expenseService.createExpense(groupId, request, carolId))
                 .isInstanceOf(GroupAccessDeniedException.class);
         assertThatThrownBy(() -> expenseService.getExpensesForGroup(groupId, carolId))
                 .isInstanceOf(GroupAccessDeniedException.class);
+    }
+
+    // Issue #8 tests:
+
+    @Test
+    void ac3_splitsAcrossASubsetOfMembers() {
+        groupService.addMember(groupId, CAROL_EMAIL, aliceId);
+
+        var request = new CreateExpenseRequest(new BigDecimal("90.00"), "Power bill", aliceId, List.of(aliceId, carolId), null);
+
+        expenseService.createExpense(groupId, request, aliceId);
+
+        assertThat(balances()).containsOnly(
+                Map.entry(aliceId, new BigDecimal("45.00")),
+                Map.entry(bobId, new BigDecimal("0.00")),
+                Map.entry(carolId, new BigDecimal("-45.00")));
+    }
+
+    @Test
+    void ac6_atLeastOneMemberMustBeIncludedInTheSplit() {
+        var request = new CreateExpenseRequest(new BigDecimal(TAXI_AMOUNT), "Taxi", aliceId, List.of(), null);
+
+        assertThat(violations(request))
+                .extractingByKey("participantUserIds", list(String.class))
+                .containsExactly("At least one participant is required");
+    }
+
+    @Test
+    void ac7_editingAnExpenseUpdatesTheBalances() {
+        var request = new CreateExpenseRequest(new BigDecimal(GROCERIES_AMOUNT), GROCERIES, bobId, memberIds, null);
+        ExpenseResponse created = expenseService.createExpense(groupId, request, aliceId);
+
+        var updateRequest = new CreateExpenseRequest(new BigDecimal("50.00"), "Groceries and snacks", bobId, memberIds, null);
+        expenseService.updateExpense(groupId, updateRequest, aliceId, created.id());
+
+        assertThat(balances()).containsOnly(
+                Map.entry(bobId, new BigDecimal("25.00")),
+                Map.entry(aliceId, new BigDecimal("-25.00")));
+    }
+
+    @Test 
+    void ac7_removingAParticipantFromAnExpenseUpdatesTheBalances() {
+        groupService.addMember(groupId, CAROL_EMAIL, aliceId);
+        var request = new CreateExpenseRequest(new BigDecimal("90.00"), "Power bill", aliceId, List.of(aliceId, bobId, carolId), null);
+        ExpenseResponse created = expenseService.createExpense(groupId, request, aliceId);
+
+        var updateRequest = new CreateExpenseRequest(new BigDecimal("90.00"), "Power bill", aliceId, List.of(aliceId, bobId), null);
+        expenseService.updateExpense(groupId, updateRequest, aliceId, created.id());
+
+        assertThat(balances()).containsOnly(
+                Map.entry(aliceId, new BigDecimal("45.00")),
+                Map.entry(bobId, new BigDecimal("-45.00")),
+                Map.entry(carolId, new BigDecimal("0.00")));
     }
 
     private Map<Long, BigDecimal> balances() {

--- a/frontend/src/api/expenses.js
+++ b/frontend/src/api/expenses.js
@@ -32,3 +32,35 @@ export async function createExpense(id, expense) {
     }
     return { expense: await response.json() };
 }
+
+export async function updateExpense(id, expenseId, expense) {
+    const groupId = requirePositiveInteger(id, 'Group ID');
+    const response = await fetch(`${API_BASE}/groups/${groupId}/expenses/${expenseId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(expense)
+    });
+    if (response.status === 400) {
+        const body = await response.json();
+        return { errors: body.error ? { form: body.error } : body };
+    }
+    if (!response.ok) {
+        return { errors: { form: await readError(response, 'Could not update this expense.') } };
+    }
+    return {};
+}
+
+export async function getExpense(id, expenseId) {
+    const groupId = requirePositiveInteger(id, 'Group ID');
+    const response = await fetch(
+        `${API_BASE}/groups/${groupId}/expenses/${expenseId}`,
+        { credentials: 'include' }
+    );
+
+    if (!response.ok) {
+        return { error: await readError(response, 'Could not load expense.') };
+    }
+
+    return { expense: await response.json() };
+}

--- a/frontend/src/components/ExpenseForm.jsx
+++ b/frontend/src/components/ExpenseForm.jsx
@@ -1,0 +1,111 @@
+function ExpenseForm({
+    amount,
+    description,
+    paidByUserId,
+    expenseDate,
+    participantUserIds,
+    members,
+    errors,
+    submitting,
+    onAmountChange,
+    onDescriptionChange,
+    onPaidByUserIdChange,
+    onExpenseDateChange,
+    onParticipantUserIdsChange,
+    onSubmit,
+    maxExpenseDate,
+}) {
+    function handleParticipantChange(event) {
+        const userId = event.target.value;
+        onParticipantUserIdsChange((currentIds) => (
+            event.target.checked
+                ? [...currentIds, userId]
+                : currentIds.filter((id) => id !== userId)
+        ));
+    }
+
+    return (
+        <form onSubmit={onSubmit} noValidate>
+            <div className="form-group">
+                <label htmlFor="amount">Amount</label>
+                <input
+                    id="amount"
+                    type="number"
+                    step="0.01"
+                    value={amount}
+                    placeholder="0.00"
+                    onChange={(event) => onAmountChange(event.target.value)}
+                />
+                {errors.amount && <span className="error">{errors.amount}</span>}
+            </div>
+
+            <div className="form-group">
+                <label htmlFor="description">Description</label>
+                <input
+                    id="description"
+                    type="text"
+                    value={description}
+                    placeholder="What was it for?"
+                    onChange={(event) => onDescriptionChange(event.target.value)}
+                />
+                {errors.description && <span className="error">{errors.description}</span>}
+            </div>
+
+            <div className="form-group">
+                <label htmlFor="paidByUserId">Paid by</label>
+                <select
+                    id="paidByUserId"
+                    value={paidByUserId}
+                    onChange={(event) => onPaidByUserIdChange(event.target.value)}
+                >
+                    {members.map((member) => (
+                        <option key={member.userId} value={member.userId}>
+                            {member.username}
+                        </option>
+                    ))}
+                </select>
+                {errors.paidByUserId && <span className="error">{errors.paidByUserId}</span>}
+            </div>
+
+            <div className="form-group">
+                <label htmlFor="expenseDate">Date</label>
+                <input
+                    id="expenseDate"
+                    type="date"
+                    value={expenseDate}
+                    max={maxExpenseDate}
+                    onChange={(event) => onExpenseDateChange(event.target.value)}
+                />
+                {errors.expenseDate && <span className="error">{errors.expenseDate}</span>}
+            </div>
+
+            <div className="select-participants">
+                <p>Participants</p>
+                <ul>
+                    {members.map((member) => (
+                        <li key={member.userId}>
+                            <label>
+                                <input
+                                    type="checkbox"
+                                    value={member.userId}
+                                    checked={participantUserIds.includes(String(member.userId))}
+                                    onChange={handleParticipantChange}
+                                />
+                                {member.username}
+                            </label>
+                        </li>
+                    ))}
+                </ul>
+                {errors.participantUserIds && <span className="error">{errors.participantUserIds}</span>}
+            </div>
+
+            {errors.form && <span className="error">{errors.form}</span>}
+
+            <button type="submit" disabled={submitting}>
+                {submitting ? 'Saving...' : 'Save expense'}
+            </button>
+        </form>
+    );
+}
+
+export default ExpenseForm;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -13,6 +13,7 @@ import UserManagement from './pages/UserManagement.jsx';
 import './index.css';
 import App from './App.jsx';
 import {getCurrentUser} from "./api/users.js";
+import EditExpense from './pages/ManageExpense.jsx';
 
 /** Sends visitors without a session to the login page before the route renders. */
 async function requireAuth() {
@@ -68,6 +69,11 @@ const router = createBrowserRouter([
             {
                 path: '/groups/:id/expenses/new',
                 element: <AddExpense/>,
+                loader: requireAuth
+            },
+            {
+                path: '/groups/:id/expenses/:expenseId/edit',
+                element: <EditExpense/>,
                 loader: requireAuth
             }
         ]

--- a/frontend/src/pages/AddExpense.jsx
+++ b/frontend/src/pages/AddExpense.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { getGroupMembers } from '../api/groups';
 import { createExpense } from '../api/expenses';
+import ExpenseForm from '../components/ExpenseForm';
 import './AddExpense.css';
 
 // Built from local date because toISOString() reports the UTC date and
@@ -117,94 +118,23 @@ function AddExpense() {
                 <h1>Add an expense</h1>
                 <p className="subtitle">Split equally among selected members</p>
 
-                <form onSubmit={handleSubmit} noValidate>
-                    <div className="form-group">
-                        <label htmlFor="amount">Amount</label>
-                        <input
-                            id="amount"
-                            type="number"
-                            step="0.01"
-                            value={amount}
-                            placeholder="0.00"
-                            onChange={(event) => setAmount(event.target.value)}
-                        />
-                        {errors.amount && <span className="error">{errors.amount}</span>}
-                    </div>
-
-                    <div className="form-group">
-                        <label htmlFor="description">Description</label>
-                        <input
-                            id="description"
-                            type="text"
-                            value={description}
-                            placeholder="What was it for?"
-                            onChange={(event) => setDescription(event.target.value)}
-                        />
-                        {errors.description && <span className="error">{errors.description}</span>}
-                    </div>
-
-                    <div className="form-group">
-                        <label htmlFor="paidByUserId">Paid by</label>
-                        <select
-                            id="paidByUserId"
-                            value={paidByUserId}
-                            onChange={(event) => setPaidByUserId(event.target.value)}
-                        >
-                            {/* AC5: only current members of the group */}
-                            {members.map((member) => (
-                                <option key={member.userId} value={member.userId}>
-                                    {member.username}
-                                </option>
-                            ))}
-                        </select>
-                        {errors.paidByUserId && <span className="error">{errors.paidByUserId}</span>}
-                    </div>
-
-                    <div className="form-group">
-                        <label htmlFor="expenseDate">Date</label>
-                        <input
-                            id="expenseDate"
-                            type="date"
-                            value={expenseDate}
-                            max={today()}                 // AC6: past dates only
-                            onChange={(event) => setExpenseDate(event.target.value)}
-                        />
-                        {errors.expenseDate && <span className="error">{errors.expenseDate}</span>}
-                    </div>
-
-                    <div className="select-participants"> {/* #8 AC3: split among a subset of the group */}
-                        <p>Participants</p>
-                        <ul>
-                            {members.map((member) => (
-                                <li key={member.userId}>
-                                    <label>
-                                        <input
-                                            type="checkbox"
-                                            value={member.userId}
-                                            checked={participantUserIds.includes(String(member.userId))}
-                                            onChange={(event) => {
-                                                const userId = event.target.value;
-                                                if (event.target.checked) {
-                                                    setParticipantUserIds((currentIds) => [...currentIds, userId]);
-                                                } else {
-                                                    setParticipantUserIds((currentIds) => currentIds.filter((id) => id !== userId));
-                                                }
-                                            }}
-                                        />
-                                        {member.username}
-                                    </label>
-                                </li>
-                            ))}
-                        </ul>
-                        {errors.participantUserIds && <span className="error">{errors.participantUserIds}</span>}
-                    </div>
-
-                    {errors.form && <span className="error">{errors.form}</span>}
-
-                    <button type="submit" disabled={submitting}>
-                        {submitting ? 'Saving…' : 'Save expense'}
-                    </button>
-                </form>
+                <ExpenseForm
+                    amount={amount}
+                    description={description}
+                    paidByUserId={paidByUserId}
+                    expenseDate={expenseDate}
+                    participantUserIds={participantUserIds}
+                    members={members}
+                    errors={errors}
+                    submitting={submitting}
+                    onAmountChange={setAmount}
+                    onDescriptionChange={setDescription}
+                    onPaidByUserIdChange={setPaidByUserId}
+                    onExpenseDateChange={setExpenseDate}
+                    onParticipantUserIdsChange={setParticipantUserIds}
+                    onSubmit={handleSubmit}
+                    maxExpenseDate={today()}
+                />
 
                 <Link to={`/groups/${id}`}>Back to the group</Link>
             </div>

--- a/frontend/src/pages/GroupPage.jsx
+++ b/frontend/src/pages/GroupPage.jsx
@@ -99,13 +99,15 @@ function GroupPage() {
                     <h2>Expenses</h2>
                     <Link className="action" to={`/groups/${id}/expenses/new`}>Add an expense</Link>
 
-                    {/* AC7: every member sees the expense with amount, description, payer and date */}
+                    {/* AC7: every member sees the expense with amount, description, payer and date */} 
+                    {/* #8 AC7: Expenses can be edited */}
                     {expenses.length === 0 ? (
                         <p className="empty">No expenses yet.</p>
                     ) : (
                         <ul className="expense-list">
                             {expenses.map((expense) => (
                                 <li key={expense.id}>
+                                    <Link className="action" to={`/groups/${id}/expenses/${expense.id}/edit`}>Edit</Link>
                                     <span className="expense-description">{expense.description}</span>
                                     <span className="expense-meta">
                                         {expense.paidByUsername} paid on {expense.expenseDate}

--- a/frontend/src/pages/ManageExpense.css
+++ b/frontend/src/pages/ManageExpense.css
@@ -1,0 +1,8 @@
+.form-group select {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    font-size: 14px;
+    background: #fff;
+}

--- a/frontend/src/pages/ManageExpense.jsx
+++ b/frontend/src/pages/ManageExpense.jsx
@@ -1,122 +1,90 @@
-import { useEffect, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
-import { getGroupMembers } from '../api/groups';
-import { createExpense } from '../api/expenses';
-import './AddExpense.css';
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { getGroupMembers } from "../api/groups";
+import { getExpense, updateExpense } from "../api/expenses";
+import { Link } from "react-router-dom";
+import './ManageExpense.css';
 
-// Built from local date because toISOString() reports the UTC date and
-// would give yesterday for the first hours of a New Zealand day.
-function today() {
-    const now = new Date();
-    const month = String(now.getMonth() + 1).padStart(2, '0');
-    const day = String(now.getDate()).padStart(2, '0');
-    return `${now.getFullYear()}-${month}-${day}`;
+function Validate({ amount, description, paidByUserId, expenseId }) {
 }
 
-function validate({ amount, description, paidByUserId, expenseDate, participantUserIds }) {
-    const errors = {};
-
-    if (amount.trim() === '') {
-        errors.amount = 'Amount is required';                          // AC2
-    } else if (!(Number(amount) > 0)) {
-        errors.amount = 'Amount must be a positive number';            // AC3
-    }
-
-    if (description.trim() === '') {
-        errors.description = 'Description is required';                // AC2
-    }
-
-    if (paidByUserId === '') {
-        errors.paidByUserId = 'Payer is required';                     // AC2
-    }
-
-    if (expenseDate > today()) {
-        errors.expenseDate = 'Expense date cannot be in the future';   // AC6
-    }
-
-    if (!participantUserIds || participantUserIds.length === 0) {
-        errors.participantUserIds = 'At least one participant is required';   // AC4
-    }
-
-    return errors;
-}
-
-function AddExpense() {
-    const { id } = useParams();
+function EditExpense() {
+    const { id, expenseId } = useParams();
     const navigate = useNavigate();
     const [members, setMembers] = useState([]);
-    const [amount, setAmount] = useState('');
-    const [description, setDescription] = useState('');
-    const [paidByUserId, setPaidByUserId] = useState('');
-    const [expenseDate, setExpenseDate] = useState(today());   // AC6
+    const [expense, setExpense] = useState(null);
     const [loading, setLoading] = useState(true);
     const [submitting, setSubmitting] = useState(false);
     const [errors, setErrors] = useState({});
+    const [amount, setAmount] = useState('');
+    const [description, setDescription] = useState('');
+    const [paidByUserId, setPaidByUserId] = useState('');
+    const [expenseDate, setExpenseDate] = useState('');
     const [participantUserIds, setParticipantUserIds] = useState([]);  // #8 AC3
 
     useEffect(() => {
-        async function loadMembers() {
-            const result = await getGroupMembers(id);
-            if (result.error) {
-                setErrors({ form: result.error });                     // AC8
+        async function loadData() {
+            const [membersResult, expenseResult] = await Promise.all([
+                getGroupMembers(id),
+                getExpense(id, expenseId)
+            ]);
+
+            if (membersResult.error) {
+                setErrors({ form: membersResult.error });
             } else {
-                setMembers(result.members);                            // AC5
-                const self = result.members.find((member) => member.currentUser);
-                setPaidByUserId(String((self ?? result.members[0])?.userId ?? ''));
+                setMembers(membersResult.members);
+            }
+            if (expenseResult.error) {
+                setErrors({ form: expenseResult.error });
+            } else {
+                setExpense(expenseResult.expense);
+                setAmount(String(expenseResult.expense.amount));
+                setDescription(expenseResult.expense.description);
+                setPaidByUserId(String(expenseResult.expense.paidByUserId));
+                setExpenseDate(expenseResult.expense.expenseDate);
             }
             setLoading(false);
         }
 
-        loadMembers().catch(() => {
-            setErrors({ form: 'Could not load group members.' });
+        loadData().catch(() => {
+            setErrors({ form: 'Could not load data.' });
             setLoading(false);
         });
-    }, [id]);
+    }, [id, expenseId]);
 
     async function handleSubmit(event) {
         event.preventDefault();
 
-        const found = validate({ amount, description, paidByUserId, expenseDate, participantUserIds });
-        if (Object.keys(found).length > 0) {
-            setErrors(found);
+        if (participantUserIds.length === 0) {
+            setErrors({ participantUserIds: 'At least one participant must be selected.' });
             return;
         }
 
-        setSubmitting(true);
-        setErrors({});
+        const result = await updateExpense(id, expenseId, {
+            amount,
+            description,
+            paidByUserId: Number(paidByUserId),
+            expenseDate,
+            participantUserIds: participantUserIds.map(Number)
+        });
 
-        try {
-            const result = await createExpense(id, {
-                amount,
-                description,
-                paidByUserId: Number(paidByUserId),
-                expenseDate,
-                participantUserIds: participantUserIds.map(Number)
-            });
-
-            if (result.errors) {
-                setErrors(result.errors);
-                return;
-            }
-
-            navigate(`/groups/${id}`);          // AC7: back to the list the expense now appears in
-        } catch {
-            setErrors({ form: 'Could not add this expense. Please try again.' });
-        } finally {
-            setSubmitting(false);
+        if (result.errors) {
+            setErrors(result.errors);
+            return;
         }
+
+        navigate(`/groups/${id}`);
     }
 
     if (loading) {
-        return <div className="page"><p>Loading…</p></div>;
+        return <p>Loading...</p>;
     }
 
     return (
         <div className="page">
             <div className="card">
-                <h1>Add an expense</h1>
-                <p className="subtitle">Split equally among selected members</p>
-
+                <h2>Edit Expense</h2>
+                <p className="subtitle">Edit the details of this expense</p>
                 <form onSubmit={handleSubmit} noValidate>
                     <div className="form-group">
                         <label htmlFor="amount">Amount</label>
@@ -125,7 +93,6 @@ function AddExpense() {
                             type="number"
                             step="0.01"
                             value={amount}
-                            placeholder="0.00"
                             onChange={(event) => setAmount(event.target.value)}
                         />
                         {errors.amount && <span className="error">{errors.amount}</span>}
@@ -137,7 +104,6 @@ function AddExpense() {
                             id="description"
                             type="text"
                             value={description}
-                            placeholder="What was it for?"
                             onChange={(event) => setDescription(event.target.value)}
                         />
                         {errors.description && <span className="error">{errors.description}</span>}
@@ -158,18 +124,6 @@ function AddExpense() {
                             ))}
                         </select>
                         {errors.paidByUserId && <span className="error">{errors.paidByUserId}</span>}
-                    </div>
-
-                    <div className="form-group">
-                        <label htmlFor="expenseDate">Date</label>
-                        <input
-                            id="expenseDate"
-                            type="date"
-                            value={expenseDate}
-                            max={today()}                 // AC6: past dates only
-                            onChange={(event) => setExpenseDate(event.target.value)}
-                        />
-                        {errors.expenseDate && <span className="error">{errors.expenseDate}</span>}
                     </div>
 
                     <div className="select-participants"> {/* #8 AC3: split among a subset of the group */}
@@ -212,4 +166,4 @@ function AddExpense() {
     );
 }
 
-export default AddExpense;
+export default EditExpense;

--- a/frontend/src/pages/ManageExpense.jsx
+++ b/frontend/src/pages/ManageExpense.jsx
@@ -1,18 +1,14 @@
-import { useState, useEffect } from "react";
-import { useParams, useNavigate } from "react-router-dom";
-import { getGroupMembers } from "../api/groups";
-import { getExpense, updateExpense } from "../api/expenses";
-import { Link } from "react-router-dom";
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { getGroupMembers } from '../api/groups';
+import { getExpense, updateExpense } from '../api/expenses';
+import ExpenseForm from '../components/ExpenseForm';
 import './ManageExpense.css';
-
-function Validate({ amount, description, paidByUserId, expenseId }) {
-}
 
 function EditExpense() {
     const { id, expenseId } = useParams();
     const navigate = useNavigate();
     const [members, setMembers] = useState([]);
-    const [expense, setExpense] = useState(null);
     const [loading, setLoading] = useState(true);
     const [submitting, setSubmitting] = useState(false);
     const [errors, setErrors] = useState({});
@@ -37,7 +33,6 @@ function EditExpense() {
             if (expenseResult.error) {
                 setErrors({ form: expenseResult.error });
             } else {
-                setExpense(expenseResult.expense);
                 setAmount(String(expenseResult.expense.amount));
                 setDescription(expenseResult.expense.description);
                 setPaidByUserId(String(expenseResult.expense.paidByUserId));
@@ -60,20 +55,27 @@ function EditExpense() {
             return;
         }
 
-        const result = await updateExpense(id, expenseId, {
-            amount,
-            description,
-            paidByUserId: Number(paidByUserId),
-            expenseDate,
-            participantUserIds: participantUserIds.map(Number)
-        });
+        setSubmitting(true);
+        setErrors({});
 
-        if (result.errors) {
-            setErrors(result.errors);
-            return;
+        try {
+            const result = await updateExpense(id, expenseId, {
+                amount,
+                description,
+                paidByUserId: Number(paidByUserId),
+                expenseDate,
+                participantUserIds: participantUserIds.map(Number)
+            });
+
+            if (result.errors) {
+                setErrors(result.errors);
+                return;
+            }
+
+            navigate(`/groups/${id}`);
+        } finally {
+            setSubmitting(false);
         }
-
-        navigate(`/groups/${id}`);
     }
 
     if (loading) {
@@ -85,80 +87,22 @@ function EditExpense() {
             <div className="card">
                 <h2>Edit Expense</h2>
                 <p className="subtitle">Edit the details of this expense</p>
-                <form onSubmit={handleSubmit} noValidate>
-                    <div className="form-group">
-                        <label htmlFor="amount">Amount</label>
-                        <input
-                            id="amount"
-                            type="number"
-                            step="0.01"
-                            value={amount}
-                            onChange={(event) => setAmount(event.target.value)}
-                        />
-                        {errors.amount && <span className="error">{errors.amount}</span>}
-                    </div>
-
-                    <div className="form-group">
-                        <label htmlFor="description">Description</label>
-                        <input
-                            id="description"
-                            type="text"
-                            value={description}
-                            onChange={(event) => setDescription(event.target.value)}
-                        />
-                        {errors.description && <span className="error">{errors.description}</span>}
-                    </div>
-
-                    <div className="form-group">
-                        <label htmlFor="paidByUserId">Paid by</label>
-                        <select
-                            id="paidByUserId"
-                            value={paidByUserId}
-                            onChange={(event) => setPaidByUserId(event.target.value)}
-                        >
-                            {/* AC5: only current members of the group */}
-                            {members.map((member) => (
-                                <option key={member.userId} value={member.userId}>
-                                    {member.username}
-                                </option>
-                            ))}
-                        </select>
-                        {errors.paidByUserId && <span className="error">{errors.paidByUserId}</span>}
-                    </div>
-
-                    <div className="select-participants"> {/* #8 AC3: split among a subset of the group */}
-                        <p>Participants</p>
-                        <ul>
-                            {members.map((member) => (
-                                <li key={member.userId}>
-                                    <label>
-                                        <input
-                                            type="checkbox"
-                                            value={member.userId}
-                                            checked={participantUserIds.includes(String(member.userId))}
-                                            onChange={(event) => {
-                                                const userId = event.target.value;
-                                                if (event.target.checked) {
-                                                    setParticipantUserIds((currentIds) => [...currentIds, userId]);
-                                                } else {
-                                                    setParticipantUserIds((currentIds) => currentIds.filter((id) => id !== userId));
-                                                }
-                                            }}
-                                        />
-                                        {member.username}
-                                    </label>
-                                </li>
-                            ))}
-                        </ul>
-                        {errors.participantUserIds && <span className="error">{errors.participantUserIds}</span>}
-                    </div>
-
-                    {errors.form && <span className="error">{errors.form}</span>}
-
-                    <button type="submit" disabled={submitting}>
-                        {submitting ? 'Saving…' : 'Save expense'}
-                    </button>
-                </form>
+                <ExpenseForm
+                    amount={amount}
+                    description={description}
+                    paidByUserId={paidByUserId}
+                    expenseDate={expenseDate}
+                    participantUserIds={participantUserIds}
+                    members={members}
+                    errors={errors}
+                    submitting={submitting}
+                    onAmountChange={setAmount}
+                    onDescriptionChange={setDescription}
+                    onPaidByUserIdChange={setPaidByUserId}
+                    onExpenseDateChange={setExpenseDate}
+                    onParticipantUserIdsChange={setParticipantUserIds}
+                    onSubmit={handleSubmit}
+                />
 
                 <Link to={`/groups/${id}`}>Back to the group</Link>
             </div>

--- a/frontend/src/pages/ManageExpense.jsx
+++ b/frontend/src/pages/ManageExpense.jsx
@@ -37,6 +37,7 @@ function EditExpense() {
                 setDescription(expenseResult.expense.description);
                 setPaidByUserId(String(expenseResult.expense.paidByUserId));
                 setExpenseDate(expenseResult.expense.expenseDate);
+                setParticipantUserIds(expenseResult.expense.participantUserIds.map(String));
             }
             setLoading(false);
         }

--- a/frontend/test/AddExpense.test.jsx
+++ b/frontend/test/AddExpense.test.jsx
@@ -50,6 +50,8 @@ it('AC1: saves the expense and returns to the group', async () => {
     await user.type(await screen.findByLabelText('Amount'), '42.50');
     await user.type(screen.getByLabelText('Description'), 'Groceries');
     await user.selectOptions(screen.getByLabelText('Paid by'), '2');
+    await user.click(screen.getByRole('checkbox', { name: 'alice' }));
+    await user.click(screen.getByRole('checkbox', { name: 'bob' }));
     await user.click(screen.getByRole('button', { name: 'Save expense' }));
 
     // The number input normalises 42.50 to 42.5; the backend stores it at two decimal places.
@@ -58,6 +60,7 @@ it('AC1: saves the expense and returns to the group', async () => {
         description: 'Groceries',
         paidByUserId: 2,
         expenseDate: today(),
+        participantUserIds: [1, 2],
     });
     expect(await screen.findByText('Flat 3')).toBeInTheDocument();
 });
@@ -79,6 +82,7 @@ it('AC3: rejects a zero, negative or non-numeric amount', async () => {
 
     const amount = await screen.findByLabelText('Amount');
     await user.type(screen.getByLabelText('Description'), 'Groceries');
+    await user.click(screen.getByRole('checkbox', { name: 'alice' }));
 
     for (const value of ['0', '-5']) {
         await user.clear(amount);
@@ -144,6 +148,7 @@ it('AC5: shows the error when the payer is no longer a group member', async () =
 
     await user.type(await screen.findByLabelText('Amount'), '10');
     await user.type(screen.getByLabelText('Description'), 'Taxi');
+    await user.click(screen.getByRole('checkbox', { name: 'alice' }));
     await user.click(screen.getByRole('button', { name: 'Save expense' }));
 
     expect(await screen.findByText('Payer must be a member of the group')).toBeInTheDocument();

--- a/frontend/test/ManageExpense.test.jsx
+++ b/frontend/test/ManageExpense.test.jsx
@@ -24,7 +24,14 @@ const MEMBERS = [
 beforeEach(() => {
     vi.clearAllMocks();
     getGroupMembers.mockResolvedValue({ members: MEMBERS });
-    getExpense.mockResolvedValue({ expense: { id: 9, amount: '42.50', description: 'Groceries', paidByUserId: 2, expenseDate: '2024-06-15' } });
+    getExpense.mockResolvedValue({ expense: {
+        id: 9,
+        amount: '42.50',
+        description: 'Groceries',
+        paidByUserId: 2,
+        expenseDate: '2024-06-15',
+        participantUserIds: [1, 2]
+    } });
     updateExpense.mockResolvedValue({ expense: { id: 9 } });
 });
 
@@ -39,21 +46,28 @@ function renderPage() {
     );
 }
 
+it('preselects the expense participants', async () => {
+    renderPage();
+
+    expect(await screen.findByRole('checkbox', { name: 'alice' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'bob' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'carol' })).not.toBeChecked();
+});
+
 it('AC3: split across a subset of members', async () => {
     const user = userEvent.setup();
     renderPage();
 
     await user.selectOptions(await screen.findByLabelText('Paid by'), '2');
-    // Select only Alice and Bob as participants
-    await user.click(screen.getByLabelText('alice'));
-    await user.click(screen.getByLabelText('bob'));
+    // Alice and Bob are the saved participants; add Carol to change the split.
+    await user.click(screen.getByLabelText('carol'));
     await user.click(screen.getByRole('button', { name: 'Save expense' }));
     expect(updateExpense).toHaveBeenCalledWith('1', '9', {
         amount: '42.50',
         description: 'Groceries',
         paidByUserId: 2,
         expenseDate: '2024-06-15',
-        participantUserIds: [1, 2], // Only Alice and Bob
+        participantUserIds: [1, 2, 3],
     });
 });
 
@@ -64,6 +78,8 @@ it('AC6: at least one participant must be selected', async () => {
     await user.type(await screen.findByLabelText('Amount'), '42.50');
     await user.type(screen.getByLabelText('Description'), 'Groceries');
     await user.selectOptions(screen.getByLabelText('Paid by'), '2');
+    await user.click(screen.getByLabelText('alice'));
+    await user.click(screen.getByLabelText('bob'));
     await user.click(screen.getByRole('button', { name: 'Save expense' }));
     expect(await screen.findByText('At least one participant must be selected.')).toBeInTheDocument();
     expect(updateExpense).not.toHaveBeenCalled();

--- a/frontend/test/ManageExpense.test.jsx
+++ b/frontend/test/ManageExpense.test.jsx
@@ -1,0 +1,70 @@
+import { it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import ManageExpense from '../src/pages/ManageExpense.jsx';
+import { getGroupMembers } from '../src/api/groups';
+import { getExpense, updateExpense } from '../src/api/expenses';
+
+vi.mock('../src/api/groups', () => ({
+    getGroupMembers: vi.fn(),
+}));
+
+vi.mock('../src/api/expenses', () => ({
+    getExpense: vi.fn(),
+    updateExpense: vi.fn(),
+}));
+
+const MEMBERS = [
+    { userId: 1, username: 'alice', email: 'alice@test.com' },
+    { userId: 2, username: 'bob', email: 'bob@test.com' },
+    { userId: 3, username: 'carol', email: 'carol@test.com' },
+];
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    getGroupMembers.mockResolvedValue({ members: MEMBERS });
+    getExpense.mockResolvedValue({ expense: { id: 9, amount: '42.50', description: 'Groceries', paidByUserId: 2, expenseDate: '2024-06-15' } });
+    updateExpense.mockResolvedValue({ expense: { id: 9 } });
+});
+
+function renderPage() {
+    render(
+        <MemoryRouter initialEntries={['/groups/1/expenses/9/edit']}>
+            <Routes>
+                <Route path="/groups/:id/expenses/:expenseId/edit" element={<ManageExpense />} />
+                <Route path="/groups/:id" element={<h1>Flat 3</h1>} />
+            </Routes>
+        </MemoryRouter>
+    );
+}
+
+it('AC3: split across a subset of members', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.selectOptions(await screen.findByLabelText('Paid by'), '2');
+    // Select only Alice and Bob as participants
+    await user.click(screen.getByLabelText('alice'));
+    await user.click(screen.getByLabelText('bob'));
+    await user.click(screen.getByRole('button', { name: 'Save expense' }));
+    expect(updateExpense).toHaveBeenCalledWith('1', '9', {
+        amount: '42.50',
+        description: 'Groceries',
+        paidByUserId: 2,
+        expenseDate: '2024-06-15',
+        participantUserIds: [1, 2], // Only Alice and Bob
+    });
+});
+
+it('AC6: at least one participant must be selected', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(await screen.findByLabelText('Amount'), '42.50');
+    await user.type(screen.getByLabelText('Description'), 'Groceries');
+    await user.selectOptions(screen.getByLabelText('Paid by'), '2');
+    await user.click(screen.getByRole('button', { name: 'Save expense' }));
+    expect(await screen.findByText('At least one participant must be selected.')).toBeInTheDocument();
+    expect(updateExpense).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
Adds the ability to select which users are included in an expense (i.e. which users owe some money to the payer), and to edit existing expenses.

## Associated issue
Closes #8

## Changes
- When adding a new expense, users can now select which group members are involved in that expense, and only the net balances of those members will be updated.
- When viewing expenses in the group page, there is now an option to edit expenses, which will take the user to a page similar to the add expenses page where they can edit the details of the expense. This automatically recalculates all members balances.
- Database now stores Expense Shares, relating expenses to users.

## Testing
`npm test` in `frontend` : 42/42 tests passed.
`./mvnw --batch-mode clean verify` in Docker terminal `Tests run: 48, Failures: 0, Errors: 0, Skipped: 0`
Manual checks that swapping users involved and payer properly recalculated balances across various sequences and inputs.

## Dependencies
No new dependancies

## Screenshots
<img width="200" height="290" alt="image" src="https://github.com/user-attachments/assets/2a51ed68-54b6-49a3-879c-f7734f6d81b6" /> <img width="200" height="290" alt="image" src="https://github.com/user-attachments/assets/dd7979fe-aabf-480c-a9dc-209da35a57f7" />


## Reviewer notes
Expecting conflict with #53.

## Generative AI
Github Copilot used for code completion, searching for bugs, and some code migration.

## Checklist

- [x] Associated with an open, team-approved issue
- [x] Branched from `main` and rebased against it
- [x] Test suite passes and the application runs
- [x] Tests are added alongside any new or modified code
- [x] No unrelated changes are included
- [x] Documentation updated where the change requires it
- [x] Any use of generative AI is acknowledged above
