### PR TITLE
Bug-fix: Patched jackson databind vulnerability

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -19,6 +19,7 @@
 
     <properties>
         <java.version>21</java.version>
+        <jackson-bom.version>3.1.5</jackson-bom.version>
         <!-- Overrides the Boot-managed 1.5.34, which is affected by CVE-2026-13006. -->
         <logback.version>1.5.36</logback.version>
     </properties>
@@ -77,12 +78,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>tools.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>3.1.5</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -78,6 +78,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>3.1.5</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Summary
Overrides jackson databind to use 3.1.5 with no known vulnerabilities.

## Associated issue
Closes #31
## Changes
- Now uses jackson databind 3.1.5 instead of 3.1.4.

## Testing
Ran `.\mvnw.cmd dependency:tree '-Dincludes=tools.jackson.core:jackson-databind'` confirms that 3.1.4 is not resolved.

## Dependencies
Now uses jackson databind 3.1.5 instead of 3.1.4.

## Reviewer notes
Check Snyk for vulnerabilities.

## Checklist

- [x] Associated with an open, team-approved issue
- [x] Branched from `main` and rebased against it
- [x] Test suite passes and the application runs
- [x] Tests are added alongside any new or modified code
- [x] No unrelated changes are included
- [x] Documentation updated where the change requires it
- [x] Any use of generative AI is acknowledged above
