### PR TITLE
Upgrade embedded Tomcat to remediate five Snyk findings

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -20,6 +20,8 @@
     <properties>
         <java.version>21</java.version>
         <jackson-bom.version>3.1.5</jackson-bom.version>
+        <!-- Aligns all embedded Tomcat modules on a release containing the security fixes tracked in #30. -->
+        <tomcat.version>11.0.24</tomcat.version>
         <!-- Overrides the Boot-managed 1.5.34, which is affected by CVE-2026-13006. -->
         <logback.version>1.5.36</logback.version>
     </properties>


### PR DESCRIPTION
## Summary
Upgrades the Spring Boot-managed embedded Tomcat modules from 11.0.22 to 11.0.24 to resolve the five Snyk findings tracked in Issue #30.

## Associated issue
Closes #30

## Changes
- Adds the tomcat.version override at 11.0.24.
- Keeps tomcat-embed-core, tomcat-embed-el and tomcat-embed-websocket aligned.

## Testing
- Maven dependency tree: all three embedded Tomcat modules resolved to 11.0.24.
- Backend clean verify: 44 tests passed with no failures, errors or skips.
- Frontend tests: 48 tests passed.
- Frontend production build passed.
- Backend started against MySQL 8.4 and reported Apache Tomcat/11.0.24 on port 8080.

## Dependencies
No new dependency was added. This only overrides the existing Spring Boot-managed Tomcat version.

## Screenshots
Not applicable because there is no visible UI change.

## Reviewer notes
Please confirm that the Tomcat modules stay aligned and that Snyk no longer reports the five findings from Issue #30.

## Checklist

- [x] Associated with an open, team-approved issue
- [x] Branched from main and rebased against it
- [x] Test suite passes and the application runs
- [x] Existing tests cover the dependency compatibility change
- [x] No unrelated changes are included
- [x] Documentation is not required for this dependency patch